### PR TITLE
Update descriptions, rename to portal_url and portal_key, other minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ config = Configuration(
 )
 ```
 
-You can also set the URL using the environment variable `INFOBLOX_PORTAL_URL`
+You can also set the URL using the environment variable `INFOBLOX_PORTAL_URL` or `BLOXONE_CSP_URL`.
+
+> **Note:** `BLOXONE_CSP_URL` is subject to deprecation in future releases. It is recommended to use `INFOBLOX_PORTAL_URL` instead.
+
 
 ### Authorization
 
@@ -102,9 +105,11 @@ config = Configuration(
 )
 ```
 
-Alternatively, You can also set the API key using the environment variable `INFOBLOX_PORTAL_KEY`
+Alternatively, You can also set the API key using the environment variable `INFOBLOX_PORTAL_KEY` or `BLOXONE_API_KEY` .
 
-Note: The API key is a secret and should be handled securely. Hardcoding the API key in your code is not recommended.
+> **Note:** `BLOXONE_API_KEY` is subject to deprecation in future releases. It is recommended to use `INFOBLOX_PORTAL_KEY` instead.
+
+> **Note:** The API key is a secret and should be handled securely. Hardcoding the API key in your code is not recommended.
 
 ### Default Tags
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The default URL for the Cloud Services Portal is `https://csp.infoblox.com`. If 
 from universal_ddi_client import Configuration
 
 config = Configuration(
-    csp_url = "https://csp.eu.infoblox.com",
+    portal_url = "https://csp.eu.infoblox.com",
 )
 ```
 
@@ -101,7 +101,7 @@ To use an API key with Infoblox API, you can create a new instance of Configurat
 from universal_ddi_client import Configuration
 
 config = Configuration(
-    api_key = "API_KEY",
+    portal_key = "PORTAL_KEY",
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ config = Configuration(
 
 You can also set the URL using the environment variable `INFOBLOX_PORTAL_URL` or `BLOXONE_CSP_URL`.
 
-> **Note:** `BLOXONE_CSP_URL` is subject to deprecation in future releases. It is recommended to use `INFOBLOX_PORTAL_URL` instead.
+> **Note:** `BLOXONE_CSP_URL` is deprecated and will be removed in future releases. It is recommended to use `INFOBLOX_PORTAL_URL` instead.
 
 
 ### Authorization
@@ -107,7 +107,7 @@ config = Configuration(
 
 Alternatively, You can also set the API key using the environment variable `INFOBLOX_PORTAL_KEY` or `BLOXONE_API_KEY` .
 
-> **Note:** `BLOXONE_API_KEY` is subject to deprecation in future releases. It is recommended to use `INFOBLOX_PORTAL_KEY` instead.
+> **Note:** `BLOXONE_API_KEY` is deprecated and will be removed in future releases. It is recommended to use `INFOBLOX_PORTAL_KEY` instead.
 
 > **Note:** The API key is a secret and should be handled securely. Hardcoding the API key in your code is not recommended.
 

--- a/src/anycast/README.md
+++ b/src/anycast/README.md
@@ -33,7 +33,7 @@ import anycast
 from anycast.rest import ApiException
 from pprint import pprint
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -42,7 +42,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 

--- a/src/anycast/README.md
+++ b/src/anycast/README.md
@@ -36,14 +36,14 @@ from pprint import pprint
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 
 # Enter a context with an instance of the API client

--- a/src/anycast/docs/OnPremAnycastManagerApi.md
+++ b/src/anycast/docs/OnPremAnycastManagerApi.md
@@ -45,17 +45,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = anycast.OnPremAnycastManagerApi(api_client)
     body = anycast.AnycastConfig() # AnycastConfig | 
@@ -121,17 +121,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = anycast.OnPremAnycastManagerApi(api_client)
     id = 56 # int | 
@@ -197,17 +197,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = anycast.OnPremAnycastManagerApi(api_client)
     id = 56 # int | 
@@ -273,17 +273,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = anycast.OnPremAnycastManagerApi(api_client)
     id = 56 # int | 
@@ -349,17 +349,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = anycast.OnPremAnycastManagerApi(api_client)
     id = 56 # int | 
@@ -425,17 +425,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = anycast.OnPremAnycastManagerApi(api_client)
     id = 56 # int | 
@@ -501,17 +501,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = anycast.OnPremAnycastManagerApi(api_client)
 
@@ -582,17 +582,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = anycast.OnPremAnycastManagerApi(api_client)
     id = 56 # int | 
@@ -658,17 +658,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = anycast.OnPremAnycastManagerApi(api_client)
     ophid = 'ophid_example' # str | 
@@ -738,17 +738,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = anycast.OnPremAnycastManagerApi(api_client)
     ophid = 'ophid_example' # str | 
@@ -818,17 +818,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = anycast.OnPremAnycastManagerApi(api_client)
     id = 56 # int | 
@@ -894,17 +894,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = anycast.OnPremAnycastManagerApi(api_client)
     ophid = 'ophid_example' # str | 
@@ -970,17 +970,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = anycast.OnPremAnycastManagerApi(api_client)
     ophid = 'ophid_example' # str | 
@@ -1046,17 +1046,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = anycast.OnPremAnycastManagerApi(api_client)
 
@@ -1127,17 +1127,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = anycast.OnPremAnycastManagerApi(api_client)
     id = 56 # int | 
@@ -1203,17 +1203,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = anycast.OnPremAnycastManagerApi(api_client)
     id = 56 # int | 
@@ -1281,17 +1281,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = anycast.OnPremAnycastManagerApi(api_client)
     id = 56 # int | Numeric host identifier

--- a/src/anycast/docs/OnPremAnycastManagerApi.md
+++ b/src/anycast/docs/OnPremAnycastManagerApi.md
@@ -42,7 +42,7 @@ import anycast
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -51,7 +51,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -118,7 +118,7 @@ import anycast
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -127,7 +127,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -194,7 +194,7 @@ import anycast
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -203,7 +203,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -270,7 +270,7 @@ import anycast
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -279,7 +279,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -346,7 +346,7 @@ import anycast
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -355,7 +355,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -422,7 +422,7 @@ import anycast
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -431,7 +431,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -498,7 +498,7 @@ import anycast
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -507,7 +507,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -579,7 +579,7 @@ import anycast
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -588,7 +588,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -655,7 +655,7 @@ import anycast
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -664,7 +664,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -735,7 +735,7 @@ import anycast
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -744,7 +744,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -815,7 +815,7 @@ import anycast
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -824,7 +824,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -891,7 +891,7 @@ import anycast
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -900,7 +900,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -967,7 +967,7 @@ import anycast
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -976,7 +976,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -1043,7 +1043,7 @@ import anycast
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -1052,7 +1052,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -1124,7 +1124,7 @@ import anycast
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -1133,7 +1133,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -1200,7 +1200,7 @@ import anycast
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -1209,7 +1209,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -1278,7 +1278,7 @@ import anycast
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -1287,7 +1287,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/cloud_discovery/README.md
+++ b/src/cloud_discovery/README.md
@@ -36,14 +36,14 @@ from pprint import pprint
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 
 # Enter a context with an instance of the API client

--- a/src/cloud_discovery/README.md
+++ b/src/cloud_discovery/README.md
@@ -33,7 +33,7 @@ import cloud_discovery
 from cloud_discovery.rest import ApiException
 from pprint import pprint
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -42,7 +42,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 

--- a/src/cloud_discovery/docs/AccountsApi.md
+++ b/src/cloud_discovery/docs/AccountsApi.md
@@ -29,17 +29,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = cloud_discovery.AccountsApi(api_client)
 

--- a/src/cloud_discovery/docs/AccountsApi.md
+++ b/src/cloud_discovery/docs/AccountsApi.md
@@ -26,7 +26,7 @@ import cloud_discovery
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -35,7 +35,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/cloud_discovery/docs/ProvidersApi.md
+++ b/src/cloud_discovery/docs/ProvidersApi.md
@@ -30,7 +30,7 @@ import cloud_discovery
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import cloud_discovery
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import cloud_discovery
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -262,7 +262,7 @@ import cloud_discovery
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -271,7 +271,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -339,7 +339,7 @@ import cloud_discovery
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -348,7 +348,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/cloud_discovery/docs/ProvidersApi.md
+++ b/src/cloud_discovery/docs/ProvidersApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = cloud_discovery.ProvidersApi(api_client)
     body = cloud_discovery.DiscoveryConfig() # DiscoveryConfig | 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = cloud_discovery.ProvidersApi(api_client)
     id = 'id_example' # str | 
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = cloud_discovery.ProvidersApi(api_client)
 
@@ -265,17 +265,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = cloud_discovery.ProvidersApi(api_client)
     id = 'id_example' # str | 
@@ -342,17 +342,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = cloud_discovery.ProvidersApi(api_client)
     id = 'id_example' # str | Auto-generated unique discovery config ID. Format BloxID.

--- a/src/cloud_discovery/docs/SubAccountsApi.md
+++ b/src/cloud_discovery/docs/SubAccountsApi.md
@@ -29,17 +29,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = cloud_discovery.SubAccountsApi(api_client)
     body = cloud_discovery.SubAccountListRequestV2() # SubAccountListRequestV2 | 

--- a/src/cloud_discovery/docs/SubAccountsApi.md
+++ b/src/cloud_discovery/docs/SubAccountsApi.md
@@ -26,7 +26,7 @@ import cloud_discovery
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -35,7 +35,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/dfp/README.md
+++ b/src/dfp/README.md
@@ -36,7 +36,7 @@ from pprint import pprint
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 

--- a/src/dfp/README.md
+++ b/src/dfp/README.md
@@ -33,7 +33,7 @@ import dfp
 from dfp.rest import ApiException
 from pprint import pprint
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/dfp/docs/AccountsApi.md
+++ b/src/dfp/docs/AccountsApi.md
@@ -25,7 +25,7 @@ import dfp
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/dfp/docs/AccountsApi.md
+++ b/src/dfp/docs/AccountsApi.md
@@ -28,12 +28,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dfp.AccountsApi(api_client)
     body = dfp.TypesConfigCheckRequest() # TypesConfigCheckRequest | 

--- a/src/dfp/docs/InfraServicesApi.md
+++ b/src/dfp/docs/InfraServicesApi.md
@@ -27,7 +27,7 @@ import dfp
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -102,7 +102,7 @@ import dfp
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -176,7 +176,7 @@ import dfp
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/dfp/docs/InfraServicesApi.md
+++ b/src/dfp/docs/InfraServicesApi.md
@@ -30,12 +30,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dfp.InfraServicesApi(api_client)
     payload_service_id = 'payload_service_id_example' # str | The DNS Forwarding Proxy Service ID object identifier.
@@ -105,12 +105,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dfp.InfraServicesApi(api_client)
 
@@ -179,12 +179,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dfp.InfraServicesApi(api_client)
     service_id = 'service_id_example' # str | The On-Prem Application Service identifier. For internal Use only

--- a/src/dns_config/README.md
+++ b/src/dns_config/README.md
@@ -36,14 +36,14 @@ from pprint import pprint
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 
 # Enter a context with an instance of the API client

--- a/src/dns_config/README.md
+++ b/src/dns_config/README.md
@@ -33,7 +33,7 @@ import dns_config
 from dns_config.rest import ApiException
 from pprint import pprint
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -42,7 +42,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 

--- a/src/dns_config/docs/AclApi.md
+++ b/src/dns_config/docs/AclApi.md
@@ -30,7 +30,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -262,7 +262,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -271,7 +271,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -339,7 +339,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -348,7 +348,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/dns_config/docs/AclApi.md
+++ b/src/dns_config/docs/AclApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.AclApi(api_client)
     body = dns_config.ACL() # ACL | 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.AclApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.AclApi(api_client)
 
@@ -265,17 +265,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.AclApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -342,17 +342,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.AclApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/dns_config/docs/AuthNsgApi.md
+++ b/src/dns_config/docs/AuthNsgApi.md
@@ -30,7 +30,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -262,7 +262,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -271,7 +271,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -339,7 +339,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -348,7 +348,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/dns_config/docs/AuthNsgApi.md
+++ b/src/dns_config/docs/AuthNsgApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.AuthNsgApi(api_client)
     body = dns_config.AuthNSG() # AuthNSG | 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.AuthNsgApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.AuthNsgApi(api_client)
 
@@ -265,17 +265,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.AuthNsgApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -342,17 +342,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.AuthNsgApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/dns_config/docs/AuthZoneApi.md
+++ b/src/dns_config/docs/AuthZoneApi.md
@@ -31,7 +31,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -40,7 +40,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -107,7 +107,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -116,7 +116,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -184,7 +184,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -193,7 +193,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -258,7 +258,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -267,7 +267,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -341,7 +341,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -350,7 +350,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -419,7 +419,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -428,7 +428,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/dns_config/docs/AuthZoneApi.md
+++ b/src/dns_config/docs/AuthZoneApi.md
@@ -34,17 +34,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.AuthZoneApi(api_client)
     body = dns_config.CopyAuthZone() # CopyAuthZone | 
@@ -110,17 +110,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.AuthZoneApi(api_client)
     body = dns_config.AuthZone() # AuthZone | 
@@ -187,17 +187,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.AuthZoneApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -261,17 +261,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.AuthZoneApi(api_client)
 
@@ -344,17 +344,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.AuthZoneApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -422,17 +422,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.AuthZoneApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/dns_config/docs/CacheFlushApi.md
+++ b/src/dns_config/docs/CacheFlushApi.md
@@ -29,17 +29,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.CacheFlushApi(api_client)
     body = dns_config.CacheFlush() # CacheFlush | 

--- a/src/dns_config/docs/CacheFlushApi.md
+++ b/src/dns_config/docs/CacheFlushApi.md
@@ -26,7 +26,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -35,7 +35,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/dns_config/docs/ConvertDomainNameApi.md
+++ b/src/dns_config/docs/ConvertDomainNameApi.md
@@ -29,17 +29,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ConvertDomainNameApi(api_client)
     domain_name = 'domain_name_example' # str | Input domain name in either of IDN or punycode representations.

--- a/src/dns_config/docs/ConvertDomainNameApi.md
+++ b/src/dns_config/docs/ConvertDomainNameApi.md
@@ -26,7 +26,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -35,7 +35,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/dns_config/docs/ConvertRnameApi.md
+++ b/src/dns_config/docs/ConvertRnameApi.md
@@ -26,7 +26,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -35,7 +35,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/dns_config/docs/ConvertRnameApi.md
+++ b/src/dns_config/docs/ConvertRnameApi.md
@@ -29,17 +29,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ConvertRnameApi(api_client)
     email_address = 'email_address_example' # str | Input email address.

--- a/src/dns_config/docs/DelegationApi.md
+++ b/src/dns_config/docs/DelegationApi.md
@@ -30,7 +30,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -262,7 +262,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -271,7 +271,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -339,7 +339,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -348,7 +348,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/dns_config/docs/DelegationApi.md
+++ b/src/dns_config/docs/DelegationApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.DelegationApi(api_client)
     body = dns_config.Delegation() # Delegation | 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.DelegationApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.DelegationApi(api_client)
 
@@ -265,17 +265,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.DelegationApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -342,17 +342,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.DelegationApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/dns_config/docs/ForwardNsgApi.md
+++ b/src/dns_config/docs/ForwardNsgApi.md
@@ -30,7 +30,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -262,7 +262,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -271,7 +271,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -339,7 +339,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -348,7 +348,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/dns_config/docs/ForwardNsgApi.md
+++ b/src/dns_config/docs/ForwardNsgApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ForwardNsgApi(api_client)
     body = dns_config.ForwardNSG() # ForwardNSG | 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ForwardNsgApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ForwardNsgApi(api_client)
 
@@ -265,17 +265,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ForwardNsgApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -342,17 +342,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ForwardNsgApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/dns_config/docs/ForwardZoneApi.md
+++ b/src/dns_config/docs/ForwardZoneApi.md
@@ -34,17 +34,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ForwardZoneApi(api_client)
     body = dns_config.CopyForwardZone() # CopyForwardZone | 
@@ -110,17 +110,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ForwardZoneApi(api_client)
     body = dns_config.ForwardZone() # ForwardZone | 
@@ -186,17 +186,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ForwardZoneApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -260,17 +260,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ForwardZoneApi(api_client)
 
@@ -342,17 +342,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ForwardZoneApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -419,17 +419,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ForwardZoneApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/dns_config/docs/ForwardZoneApi.md
+++ b/src/dns_config/docs/ForwardZoneApi.md
@@ -31,7 +31,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -40,7 +40,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -107,7 +107,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -116,7 +116,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -183,7 +183,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -192,7 +192,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -257,7 +257,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -266,7 +266,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -339,7 +339,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -348,7 +348,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -416,7 +416,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -425,7 +425,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/dns_config/docs/GlobalApi.md
+++ b/src/dns_config/docs/GlobalApi.md
@@ -32,17 +32,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.GlobalApi(api_client)
 
@@ -107,17 +107,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.GlobalApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -184,17 +184,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.GlobalApi(api_client)
     body = dns_config.DNSGlobal() # DNSGlobal | 
@@ -260,17 +260,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.GlobalApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/dns_config/docs/GlobalApi.md
+++ b/src/dns_config/docs/GlobalApi.md
@@ -29,7 +29,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -38,7 +38,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -104,7 +104,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -113,7 +113,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -181,7 +181,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -190,7 +190,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -257,7 +257,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -266,7 +266,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/dns_config/docs/Host.md
+++ b/src/dns_config/docs/Host.md
@@ -6,7 +6,7 @@ A DNS Host (_dns/host_) object associates DNS configuraton with hosts.   Automat
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**absolute_name** | **str** | Host FQDN. | [optional] [readonly] 
+**absolute_name** | **str** | Host FQDN. | [optional] 
 **address** | **str** | Host&#39;s primary IP Address. | [optional] [readonly] 
 **anycast_addresses** | **List[str]** | Anycast address configured to the host. Order is not significant. | [optional] [readonly] 
 **associated_server** | [**HostAssociatedServer**](HostAssociatedServer.md) | Host associated server configuration. | [optional] 

--- a/src/dns_config/docs/HostApi.md
+++ b/src/dns_config/docs/HostApi.md
@@ -31,17 +31,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.HostApi(api_client)
 
@@ -114,17 +114,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.HostApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -192,17 +192,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.HostApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/dns_config/docs/HostApi.md
+++ b/src/dns_config/docs/HostApi.md
@@ -28,7 +28,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -37,7 +37,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -111,7 +111,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -120,7 +120,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -189,7 +189,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -198,7 +198,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/dns_config/docs/LbdnApi.md
+++ b/src/dns_config/docs/LbdnApi.md
@@ -30,7 +30,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -262,7 +262,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -271,7 +271,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -339,7 +339,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -348,7 +348,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/dns_config/docs/LbdnApi.md
+++ b/src/dns_config/docs/LbdnApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.LbdnApi(api_client)
     body = dns_config.LBDN() # LBDN | 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.LbdnApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.LbdnApi(api_client)
 
@@ -265,17 +265,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.LbdnApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -342,17 +342,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.LbdnApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/dns_config/docs/ServerApi.md
+++ b/src/dns_config/docs/ServerApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ServerApi(api_client)
     body = dns_config.Server() # Server | 
@@ -110,17 +110,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ServerApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -184,17 +184,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ServerApi(api_client)
 
@@ -267,17 +267,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ServerApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -345,17 +345,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ServerApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/dns_config/docs/ServerApi.md
+++ b/src/dns_config/docs/ServerApi.md
@@ -30,7 +30,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -107,7 +107,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -116,7 +116,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -181,7 +181,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -190,7 +190,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -264,7 +264,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -273,7 +273,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -342,7 +342,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -351,7 +351,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/dns_config/docs/ViewApi.md
+++ b/src/dns_config/docs/ViewApi.md
@@ -31,7 +31,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -40,7 +40,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -107,7 +107,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -116,7 +116,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -184,7 +184,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -193,7 +193,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -258,7 +258,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -267,7 +267,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -341,7 +341,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -350,7 +350,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -419,7 +419,7 @@ import dns_config
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -428,7 +428,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/dns_config/docs/ViewApi.md
+++ b/src/dns_config/docs/ViewApi.md
@@ -34,17 +34,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ViewApi(api_client)
     body = dns_config.BulkCopyView() # BulkCopyView | 
@@ -110,17 +110,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ViewApi(api_client)
     body = dns_config.View() # View | 
@@ -187,17 +187,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ViewApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -261,17 +261,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ViewApi(api_client)
 
@@ -344,17 +344,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ViewApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -422,17 +422,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_config.ViewApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/dns_config/models/host.py
+++ b/src/dns_config/models/host.py
@@ -133,11 +133,9 @@ class Host(BaseModel):
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
-        * OpenAPI `readOnly` fields are excluded.
         * Fields in `self.additional_properties` are added to the output dict.
         """
         excluded_fields: Set[str] = set([
-            "absolute_name",
             "address",
             "anycast_addresses",
             "comment",

--- a/src/dns_data/README.md
+++ b/src/dns_data/README.md
@@ -36,14 +36,14 @@ from pprint import pprint
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 
 # Enter a context with an instance of the API client

--- a/src/dns_data/README.md
+++ b/src/dns_data/README.md
@@ -33,7 +33,7 @@ import dns_data
 from dns_data.rest import ApiException
 from pprint import pprint
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -42,7 +42,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 

--- a/src/dns_data/docs/RecordApi.md
+++ b/src/dns_data/docs/RecordApi.md
@@ -31,7 +31,7 @@ import dns_data
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -40,7 +40,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -108,7 +108,7 @@ import dns_data
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -117,7 +117,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -182,7 +182,7 @@ import dns_data
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -191,7 +191,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -265,7 +265,7 @@ import dns_data
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -274,7 +274,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -343,7 +343,7 @@ import dns_data
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -352,7 +352,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -421,7 +421,7 @@ import dns_data
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -430,7 +430,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/dns_data/docs/RecordApi.md
+++ b/src/dns_data/docs/RecordApi.md
@@ -34,17 +34,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_data.RecordApi(api_client)
     body = dns_data.Record() # Record | 
@@ -111,17 +111,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_data.RecordApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -185,17 +185,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_data.RecordApi(api_client)
 
@@ -268,17 +268,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_data.RecordApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -346,17 +346,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_data.RecordApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -424,17 +424,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = dns_data.RecordApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/fw/README.md
+++ b/src/fw/README.md
@@ -33,7 +33,7 @@ import fw
 from fw.rest import ApiException
 from pprint import pprint
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/fw/README.md
+++ b/src/fw/README.md
@@ -36,7 +36,7 @@ from pprint import pprint
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 

--- a/src/fw/docs/AccessCodesApi.md
+++ b/src/fw/docs/AccessCodesApi.md
@@ -30,7 +30,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -104,7 +104,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -174,7 +174,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -244,7 +244,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -317,7 +317,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -390,7 +390,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/fw/docs/AccessCodesApi.md
+++ b/src/fw/docs/AccessCodesApi.md
@@ -33,12 +33,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.AccessCodesApi(api_client)
     body = fw.AccessCode() # AccessCode | The Bypass Code object.
@@ -107,12 +107,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.AccessCodesApi(api_client)
     body = fw.AccessCodeDeleteRequest() # AccessCodeDeleteRequest | 
@@ -177,12 +177,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.AccessCodesApi(api_client)
     access_key = 'access_key_example' # str | The Bypass Code identifier.
@@ -247,12 +247,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.AccessCodesApi(api_client)
 
@@ -320,12 +320,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.AccessCodesApi(api_client)
     access_key = 'access_key_example' # str | The Bypass Code identifier.
@@ -393,12 +393,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.AccessCodesApi(api_client)
     payload_access_key = 'payload_access_key_example' # str | Auto generated unique Bypass Code value

--- a/src/fw/docs/AppApprovalsApi.md
+++ b/src/fw/docs/AppApprovalsApi.md
@@ -28,12 +28,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.AppApprovalsApi(api_client)
 
@@ -96,12 +96,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.AppApprovalsApi(api_client)
     body = fw.AppApprovalsReplaceRequest() # AppApprovalsReplaceRequest | 
@@ -165,12 +165,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.AppApprovalsApi(api_client)
     body = fw.AppApprovalsUpdateRequest() # AppApprovalsUpdateRequest | 

--- a/src/fw/docs/AppApprovalsApi.md
+++ b/src/fw/docs/AppApprovalsApi.md
@@ -25,7 +25,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -93,7 +93,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -162,7 +162,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/fw/docs/ApplicationFiltersApi.md
+++ b/src/fw/docs/ApplicationFiltersApi.md
@@ -33,12 +33,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.ApplicationFiltersApi(api_client)
     body = fw.ApplicationFilter() # ApplicationFilter | The Application Filter object.
@@ -104,12 +104,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.ApplicationFiltersApi(api_client)
     body = fw.ApplicationFiltersDeleteRequest() # ApplicationFiltersDeleteRequest | 
@@ -174,12 +174,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.ApplicationFiltersApi(api_client)
     id = 56 # int | The Application Filter object identifier.
@@ -244,12 +244,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.ApplicationFiltersApi(api_client)
 
@@ -320,12 +320,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.ApplicationFiltersApi(api_client)
     id = 56 # int | The Application Filter object identifier.
@@ -393,12 +393,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.ApplicationFiltersApi(api_client)
     id = 56 # int | The Application Filter object identifier.

--- a/src/fw/docs/ApplicationFiltersApi.md
+++ b/src/fw/docs/ApplicationFiltersApi.md
@@ -30,7 +30,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -101,7 +101,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -171,7 +171,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -241,7 +241,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -317,7 +317,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -390,7 +390,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/fw/docs/CategoryFiltersApi.md
+++ b/src/fw/docs/CategoryFiltersApi.md
@@ -33,12 +33,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.CategoryFiltersApi(api_client)
     body = fw.CategoryFilter() # CategoryFilter | The Category Filter object.
@@ -106,12 +106,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.CategoryFiltersApi(api_client)
     body = fw.CategoryFiltersDeleteRequest() # CategoryFiltersDeleteRequest | 
@@ -176,12 +176,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.CategoryFiltersApi(api_client)
     id = 56 # int | The Category Filter object identifier.
@@ -246,12 +246,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.CategoryFiltersApi(api_client)
 
@@ -322,12 +322,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.CategoryFiltersApi(api_client)
     id = 56 # int | The Category Filter object identifier.
@@ -396,12 +396,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.CategoryFiltersApi(api_client)
     id = 56 # int | The Category Filter object identifier.

--- a/src/fw/docs/CategoryFiltersApi.md
+++ b/src/fw/docs/CategoryFiltersApi.md
@@ -30,7 +30,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -103,7 +103,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -173,7 +173,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -243,7 +243,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -319,7 +319,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -393,7 +393,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/fw/docs/ContentCategoriesApi.md
+++ b/src/fw/docs/ContentCategoriesApi.md
@@ -28,12 +28,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.ContentCategoriesApi(api_client)
 

--- a/src/fw/docs/ContentCategoriesApi.md
+++ b/src/fw/docs/ContentCategoriesApi.md
@@ -25,7 +25,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/fw/docs/InternalDomainListsApi.md
+++ b/src/fw/docs/InternalDomainListsApi.md
@@ -34,12 +34,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.InternalDomainListsApi(api_client)
     body = fw.InternalDomains() # InternalDomains | The Internal Domains object.
@@ -107,12 +107,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.InternalDomainListsApi(api_client)
     body = fw.InternalDomainsDeleteRequest() # InternalDomainsDeleteRequest | 
@@ -178,12 +178,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.InternalDomainListsApi(api_client)
     id = 56 # int | The Internal Domains object identifiers.
@@ -249,12 +249,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.InternalDomainListsApi(api_client)
     id = 56 # int | The Internal Domain List object identifier.
@@ -324,12 +324,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.InternalDomainListsApi(api_client)
 
@@ -400,12 +400,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.InternalDomainListsApi(api_client)
     id = 56 # int | The Internal Domains object identifier.
@@ -477,12 +477,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.InternalDomainListsApi(api_client)
     id = 56 # int | The Internal Domain object identifier.

--- a/src/fw/docs/InternalDomainListsApi.md
+++ b/src/fw/docs/InternalDomainListsApi.md
@@ -31,7 +31,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -104,7 +104,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -175,7 +175,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -246,7 +246,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -321,7 +321,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -397,7 +397,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -474,7 +474,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/fw/docs/NamedListItemsApi.md
+++ b/src/fw/docs/NamedListItemsApi.md
@@ -27,7 +27,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -100,7 +100,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -175,7 +175,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/fw/docs/NamedListItemsApi.md
+++ b/src/fw/docs/NamedListItemsApi.md
@@ -30,12 +30,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.NamedListItemsApi(api_client)
     id = 56 # int | The Named List object identifier.
@@ -103,12 +103,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.NamedListItemsApi(api_client)
     id = 56 # int | The Named List object identifier.
@@ -178,12 +178,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.NamedListItemsApi(api_client)
     id = 56 # int | The Named List object identifier.

--- a/src/fw/docs/NamedListsApi.md
+++ b/src/fw/docs/NamedListsApi.md
@@ -36,12 +36,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.NamedListsApi(api_client)
     body = fw.NamedList() # NamedList | The Named List object.
@@ -109,12 +109,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.NamedListsApi(api_client)
     body = fw.NamedListsDeleteRequest() # NamedListsDeleteRequest | 
@@ -180,12 +180,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.NamedListsApi(api_client)
     id = 56 # int | The Named List object identifiers.
@@ -251,12 +251,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.NamedListsApi(api_client)
 
@@ -327,12 +327,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.NamedListsApi(api_client)
 
@@ -400,12 +400,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.NamedListsApi(api_client)
     body = fw.MultiListUpdate() # MultiListUpdate | 
@@ -473,12 +473,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.NamedListsApi(api_client)
     id = 56 # int | The Named List identifier.
@@ -551,12 +551,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.NamedListsApi(api_client)
     id = 56 # int | The Named List object identifier.
@@ -627,12 +627,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.NamedListsApi(api_client)
     id = 56 # int | The Named List object identifier.

--- a/src/fw/docs/NamedListsApi.md
+++ b/src/fw/docs/NamedListsApi.md
@@ -33,7 +33,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -106,7 +106,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -177,7 +177,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -248,7 +248,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -324,7 +324,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -397,7 +397,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -470,7 +470,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -548,7 +548,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -624,7 +624,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/fw/docs/NetworkListsApi.md
+++ b/src/fw/docs/NetworkListsApi.md
@@ -30,7 +30,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -103,7 +103,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -174,7 +174,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -245,7 +245,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -319,7 +319,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -393,7 +393,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/fw/docs/NetworkListsApi.md
+++ b/src/fw/docs/NetworkListsApi.md
@@ -33,12 +33,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.NetworkListsApi(api_client)
     body = fw.NetworkList() # NetworkList | The Network List object.
@@ -106,12 +106,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.NetworkListsApi(api_client)
     body = fw.NetworkListsDeleteRequest() # NetworkListsDeleteRequest | 
@@ -177,12 +177,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.NetworkListsApi(api_client)
     id = 56 # int | The Network List object identifier.
@@ -248,12 +248,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.NetworkListsApi(api_client)
 
@@ -322,12 +322,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.NetworkListsApi(api_client)
     id = 56 # int | The Network List object identifier.
@@ -396,12 +396,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.NetworkListsApi(api_client)
     id = 56 # int | The Network List object identifier.

--- a/src/fw/docs/PopRegionsApi.md
+++ b/src/fw/docs/PopRegionsApi.md
@@ -29,12 +29,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.PopRegionsApi(api_client)
 
@@ -105,12 +105,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.PopRegionsApi(api_client)
     id = 56 # int | The PoP region object identifier

--- a/src/fw/docs/PopRegionsApi.md
+++ b/src/fw/docs/PopRegionsApi.md
@@ -26,7 +26,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -102,7 +102,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/fw/docs/SecurityPoliciesApi.md
+++ b/src/fw/docs/SecurityPoliciesApi.md
@@ -30,7 +30,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -104,7 +104,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -174,7 +174,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -244,7 +244,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -321,7 +321,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -395,7 +395,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/fw/docs/SecurityPoliciesApi.md
+++ b/src/fw/docs/SecurityPoliciesApi.md
@@ -33,12 +33,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.SecurityPoliciesApi(api_client)
     body = fw.SecurityPolicy() # SecurityPolicy | The Security Policy object.
@@ -107,12 +107,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.SecurityPoliciesApi(api_client)
     body = fw.SecurityPolicyDeleteRequest() # SecurityPolicyDeleteRequest | 
@@ -177,12 +177,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.SecurityPoliciesApi(api_client)
     id = 56 # int | The Security Policy object identifiers.
@@ -247,12 +247,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.SecurityPoliciesApi(api_client)
 
@@ -324,12 +324,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.SecurityPoliciesApi(api_client)
     id = 56 # int | The Security Policy object identifier.
@@ -398,12 +398,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.SecurityPoliciesApi(api_client)
     id = 56 # int | The Security Policy object identifier.

--- a/src/fw/docs/SecurityPolicyRulesApi.md
+++ b/src/fw/docs/SecurityPolicyRulesApi.md
@@ -28,12 +28,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.SecurityPolicyRulesApi(api_client)
 

--- a/src/fw/docs/SecurityPolicyRulesApi.md
+++ b/src/fw/docs/SecurityPolicyRulesApi.md
@@ -25,7 +25,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/fw/docs/ThreatFeedsApi.md
+++ b/src/fw/docs/ThreatFeedsApi.md
@@ -28,12 +28,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fw.ThreatFeedsApi(api_client)
 

--- a/src/fw/docs/ThreatFeedsApi.md
+++ b/src/fw/docs/ThreatFeedsApi.md
@@ -25,7 +25,7 @@ import fw
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/infra_mgmt/README.md
+++ b/src/infra_mgmt/README.md
@@ -99,14 +99,14 @@ from pprint import pprint
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 
 # Enter a context with an instance of the API client

--- a/src/infra_mgmt/README.md
+++ b/src/infra_mgmt/README.md
@@ -96,7 +96,7 @@ import infra_mgmt
 from infra_mgmt.rest import ApiException
 from pprint import pprint
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -105,7 +105,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 

--- a/src/infra_mgmt/docs/DetailApi.md
+++ b/src/infra_mgmt/docs/DetailApi.md
@@ -25,7 +25,7 @@ import infra_mgmt
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -34,7 +34,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -105,7 +105,7 @@ import infra_mgmt
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -114,7 +114,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/infra_mgmt/docs/DetailApi.md
+++ b/src/infra_mgmt/docs/DetailApi.md
@@ -28,17 +28,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_mgmt.DetailApi(api_client)
 
@@ -108,17 +108,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_mgmt.DetailApi(api_client)
 

--- a/src/infra_mgmt/docs/HostsApi.md
+++ b/src/infra_mgmt/docs/HostsApi.md
@@ -34,7 +34,7 @@ import infra_mgmt
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -43,7 +43,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -110,7 +110,7 @@ import infra_mgmt
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -119,7 +119,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -186,7 +186,7 @@ import infra_mgmt
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -195,7 +195,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -260,7 +260,7 @@ import infra_mgmt
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -269,7 +269,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -336,7 +336,7 @@ import infra_mgmt
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -345,7 +345,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -418,7 +418,7 @@ import infra_mgmt
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -427,7 +427,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -492,7 +492,7 @@ import infra_mgmt
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -501,7 +501,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -572,7 +572,7 @@ import infra_mgmt
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -581,7 +581,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -648,7 +648,7 @@ import infra_mgmt
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -657,7 +657,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/infra_mgmt/docs/HostsApi.md
+++ b/src/infra_mgmt/docs/HostsApi.md
@@ -37,17 +37,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_mgmt.HostsApi(api_client)
     body = infra_mgmt.AssignTagsRequest() # AssignTagsRequest | 
@@ -113,17 +113,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_mgmt.HostsApi(api_client)
     body = infra_mgmt.Host() # Host | 
@@ -189,17 +189,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_mgmt.HostsApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -263,17 +263,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_mgmt.HostsApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -339,17 +339,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_mgmt.HostsApi(api_client)
 
@@ -421,17 +421,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_mgmt.HostsApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -495,17 +495,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_mgmt.HostsApi(api_client)
     from_resource_id = 'from_resource_id_example' # str | An application specific resource identity of a resource
@@ -575,17 +575,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_mgmt.HostsApi(api_client)
     body = infra_mgmt.UnassignTagsRequest() # UnassignTagsRequest | 
@@ -651,17 +651,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_mgmt.HostsApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/infra_mgmt/docs/ServicesApi.md
+++ b/src/infra_mgmt/docs/ServicesApi.md
@@ -34,17 +34,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_mgmt.ServicesApi(api_client)
 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_mgmt.ServicesApi(api_client)
     body = infra_mgmt.Service() # Service | 
@@ -185,17 +185,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_mgmt.ServicesApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -257,17 +257,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_mgmt.ServicesApi(api_client)
 
@@ -339,17 +339,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_mgmt.ServicesApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -415,17 +415,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_mgmt.ServicesApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/infra_mgmt/docs/ServicesApi.md
+++ b/src/infra_mgmt/docs/ServicesApi.md
@@ -31,7 +31,7 @@ import infra_mgmt
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -40,7 +40,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import infra_mgmt
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -182,7 +182,7 @@ import infra_mgmt
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -191,7 +191,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -254,7 +254,7 @@ import infra_mgmt
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -263,7 +263,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -336,7 +336,7 @@ import infra_mgmt
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -345,7 +345,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -412,7 +412,7 @@ import infra_mgmt
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -421,7 +421,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/infra_provision/README.md
+++ b/src/infra_provision/README.md
@@ -33,7 +33,7 @@ import infra_provision
 from infra_provision.rest import ApiException
 from pprint import pprint
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -42,7 +42,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 

--- a/src/infra_provision/README.md
+++ b/src/infra_provision/README.md
@@ -36,14 +36,14 @@ from pprint import pprint
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 
 # Enter a context with an instance of the API client

--- a/src/infra_provision/docs/UICSRApi.md
+++ b/src/infra_provision/docs/UICSRApi.md
@@ -31,17 +31,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_provision.UICSRApi(api_client)
     activation_code = 'activation_code_example' # str | activation code is used by the clients to track the approval of the CSR
@@ -107,17 +107,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_provision.UICSRApi(api_client)
     activation_code = 'activation_code_example' # str | activation code is used by the clients to track the approval of the CSR
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_provision.UICSRApi(api_client)
 
@@ -264,17 +264,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_provision.UICSRApi(api_client)
     cert_serial = 'cert_serial_example' # str | x509 serial number of the certificate. This can be obtained by parsing the client certificate file on the onprem. Either cert_serial or ophid is required
@@ -342,17 +342,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_provision.UICSRApi(api_client)
     ophid = 'ophid_example' # str | On-prem host ID which can be obtained either from on-prem or NIOS-X UI portal(Manage > Infrastructure > Hosts > Select the onprem > click on 3 dots on top right side > General Information > Ophid) .

--- a/src/infra_provision/docs/UICSRApi.md
+++ b/src/infra_provision/docs/UICSRApi.md
@@ -28,7 +28,7 @@ import infra_provision
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -37,7 +37,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -104,7 +104,7 @@ import infra_provision
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -113,7 +113,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import infra_provision
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -261,7 +261,7 @@ import infra_provision
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -270,7 +270,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -339,7 +339,7 @@ import infra_provision
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -348,7 +348,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/infra_provision/docs/UIJoinTokenApi.md
+++ b/src/infra_provision/docs/UIJoinTokenApi.md
@@ -31,7 +31,7 @@ import infra_provision
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -40,7 +40,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -105,7 +105,7 @@ import infra_provision
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -114,7 +114,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -177,7 +177,7 @@ import infra_provision
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -186,7 +186,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -251,7 +251,7 @@ import infra_provision
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -260,7 +260,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -330,7 +330,7 @@ import infra_provision
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -339,7 +339,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -407,7 +407,7 @@ import infra_provision
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -416,7 +416,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/infra_provision/docs/UIJoinTokenApi.md
+++ b/src/infra_provision/docs/UIJoinTokenApi.md
@@ -34,17 +34,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_provision.UIJoinTokenApi(api_client)
     body = infra_provision.JoinToken() # JoinToken | 
@@ -108,17 +108,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_provision.UIJoinTokenApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -180,17 +180,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_provision.UIJoinTokenApi(api_client)
     body = infra_provision.DeleteJoinTokensRequest() # DeleteJoinTokensRequest | 
@@ -254,17 +254,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_provision.UIJoinTokenApi(api_client)
 
@@ -333,17 +333,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_provision.UIJoinTokenApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -410,17 +410,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = infra_provision.UIJoinTokenApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/README.md
+++ b/src/ipam/README.md
@@ -36,14 +36,14 @@ from pprint import pprint
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 
 # Enter a context with an instance of the API client

--- a/src/ipam/README.md
+++ b/src/ipam/README.md
@@ -33,7 +33,7 @@ import ipam
 from ipam.rest import ApiException
 from pprint import pprint
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -42,7 +42,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 

--- a/src/ipam/docs/Address.md
+++ b/src/ipam/docs/Address.md
@@ -6,7 +6,7 @@ An __Address__ object (_ipam/address_) represents any single IP address within a
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**address** | **str** | The address in form \&quot;a.b.c.d\&quot;. | 
+**address** | **str** | The address in form \&quot;a.b.c.d\&quot;. | [optional]
 **comment** | **str** | The description for the address object. May contain 0 to 1024 characters. Can include UTF-8. | [optional] 
 **compartment_id** | **str** | The compartment associated with the object. If no compartment is associated with the object, the value defaults to empty. | [optional] [readonly] 
 **created_at** | **datetime** | Time when the object has been created. | [optional] [readonly] 

--- a/src/ipam/docs/AddressApi.md
+++ b/src/ipam/docs/AddressApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AddressApi(api_client)
     body = ipam.Address() # Address | 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AddressApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AddressApi(api_client)
 
@@ -267,17 +267,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AddressApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -344,17 +344,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AddressApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/docs/AddressApi.md
+++ b/src/ipam/docs/AddressApi.md
@@ -30,7 +30,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -264,7 +264,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -273,7 +273,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -341,7 +341,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -350,7 +350,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/AddressBlockApi.md
+++ b/src/ipam/docs/AddressBlockApi.md
@@ -38,7 +38,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -47,7 +47,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -116,7 +116,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -125,7 +125,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -193,7 +193,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -202,7 +202,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -274,7 +274,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -283,7 +283,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -352,7 +352,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -361,7 +361,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -434,7 +434,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -443,7 +443,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -508,7 +508,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -517,7 +517,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -591,7 +591,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -600,7 +600,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -667,7 +667,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -676,7 +676,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -749,7 +749,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -758,7 +758,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -827,7 +827,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -836,7 +836,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -909,7 +909,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -918,7 +918,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -987,7 +987,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -996,7 +996,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/AddressBlockApi.md
+++ b/src/ipam/docs/AddressBlockApi.md
@@ -41,17 +41,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AddressBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -119,17 +119,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AddressBlockApi(api_client)
     body = ipam.AddressBlock() # AddressBlock | 
@@ -196,17 +196,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AddressBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -277,17 +277,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AddressBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -355,17 +355,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AddressBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -437,17 +437,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AddressBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -511,17 +511,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AddressBlockApi(api_client)
 
@@ -594,17 +594,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AddressBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -670,17 +670,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AddressBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -752,17 +752,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AddressBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -830,17 +830,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AddressBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -912,17 +912,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AddressBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -990,17 +990,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AddressBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/docs/AsmApi.md
+++ b/src/ipam/docs/AsmApi.md
@@ -31,17 +31,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AsmApi(api_client)
     body = ipam.ASM() # ASM | 
@@ -107,17 +107,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AsmApi(api_client)
 
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.AsmApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/docs/AsmApi.md
+++ b/src/ipam/docs/AsmApi.md
@@ -28,7 +28,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -37,7 +37,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -104,7 +104,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -113,7 +113,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/ConfigProfileApi.md
+++ b/src/ipam/docs/ConfigProfileApi.md
@@ -31,7 +31,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -40,7 +40,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -107,7 +107,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -116,7 +116,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -183,7 +183,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -192,7 +192,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -259,7 +259,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -268,7 +268,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -335,7 +335,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -344,7 +344,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -410,7 +410,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -419,7 +419,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/ConfigProfileApi.md
+++ b/src/ipam/docs/ConfigProfileApi.md
@@ -34,17 +34,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.ConfigProfileApi(api_client)
     body = ipam.AssociateConfigProfileToObjectsRequest() # AssociateConfigProfileToObjectsRequest | 
@@ -110,17 +110,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.ConfigProfileApi(api_client)
     body = ipam.AssociateObjectToConfigProfilesRequest() # AssociateObjectToConfigProfilesRequest | 
@@ -186,17 +186,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.ConfigProfileApi(api_client)
     body = ipam.DisassociateConfigProfileFromObjectsRequest() # DisassociateConfigProfileFromObjectsRequest | 
@@ -262,17 +262,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.ConfigProfileApi(api_client)
     body = ipam.DisassociateObjectFromConfigProfilesRequest() # DisassociateObjectFromConfigProfilesRequest | 
@@ -338,17 +338,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.ConfigProfileApi(api_client)
 
@@ -413,17 +413,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.ConfigProfileApi(api_client)
 

--- a/src/ipam/docs/DhcpHostApi.md
+++ b/src/ipam/docs/DhcpHostApi.md
@@ -29,7 +29,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -38,7 +38,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -111,7 +111,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -120,7 +120,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -187,7 +187,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -196,7 +196,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -264,7 +264,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -273,7 +273,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/DhcpHostApi.md
+++ b/src/ipam/docs/DhcpHostApi.md
@@ -32,17 +32,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.DhcpHostApi(api_client)
 
@@ -114,17 +114,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.DhcpHostApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -190,17 +190,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.DhcpHostApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -267,17 +267,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.DhcpHostApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/docs/DnsUsageApi.md
+++ b/src/ipam/docs/DnsUsageApi.md
@@ -30,17 +30,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.DnsUsageApi(api_client)
 
@@ -110,17 +110,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.DnsUsageApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/docs/DnsUsageApi.md
+++ b/src/ipam/docs/DnsUsageApi.md
@@ -27,7 +27,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -36,7 +36,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -107,7 +107,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -116,7 +116,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/FilterApi.md
+++ b/src/ipam/docs/FilterApi.md
@@ -29,17 +29,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.FilterApi(api_client)
 

--- a/src/ipam/docs/FilterApi.md
+++ b/src/ipam/docs/FilterApi.md
@@ -26,7 +26,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -35,7 +35,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/FixedAddressApi.md
+++ b/src/ipam/docs/FixedAddressApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.FixedAddressApi(api_client)
     body = ipam.FixedAddress() # FixedAddress | 
@@ -110,17 +110,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.FixedAddressApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -184,17 +184,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.FixedAddressApi(api_client)
 
@@ -267,17 +267,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.FixedAddressApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -345,17 +345,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.FixedAddressApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/docs/FixedAddressApi.md
+++ b/src/ipam/docs/FixedAddressApi.md
@@ -30,7 +30,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -107,7 +107,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -116,7 +116,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -181,7 +181,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -190,7 +190,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -264,7 +264,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -273,7 +273,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -342,7 +342,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -351,7 +351,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/GlobalApi.md
+++ b/src/ipam/docs/GlobalApi.md
@@ -29,7 +29,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -38,7 +38,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -104,7 +104,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -113,7 +113,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -181,7 +181,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -190,7 +190,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -257,7 +257,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -266,7 +266,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/GlobalApi.md
+++ b/src/ipam/docs/GlobalApi.md
@@ -32,17 +32,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.GlobalApi(api_client)
 
@@ -107,17 +107,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.GlobalApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -184,17 +184,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.GlobalApi(api_client)
     body = ipam.DHCPGlobal() # DHCPGlobal | 
@@ -260,17 +260,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.GlobalApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/docs/HaGroupApi.md
+++ b/src/ipam/docs/HaGroupApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.HaGroupApi(api_client)
     body = ipam.HAGroup() # HAGroup | 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.HaGroupApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.HaGroupApi(api_client)
 
@@ -266,17 +266,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.HaGroupApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -344,17 +344,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.HaGroupApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/docs/HaGroupApi.md
+++ b/src/ipam/docs/HaGroupApi.md
@@ -30,7 +30,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -263,7 +263,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -272,7 +272,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -341,7 +341,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -350,7 +350,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/HardwareFilterApi.md
+++ b/src/ipam/docs/HardwareFilterApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.HardwareFilterApi(api_client)
     body = ipam.HardwareFilter() # HardwareFilter | 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.HardwareFilterApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.HardwareFilterApi(api_client)
 
@@ -265,17 +265,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.HardwareFilterApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -342,17 +342,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.HardwareFilterApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/docs/HardwareFilterApi.md
+++ b/src/ipam/docs/HardwareFilterApi.md
@@ -30,7 +30,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -262,7 +262,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -271,7 +271,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -339,7 +339,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -348,7 +348,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/IpSpaceApi.md
+++ b/src/ipam/docs/IpSpaceApi.md
@@ -33,7 +33,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -42,7 +42,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -109,7 +109,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -118,7 +118,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -187,7 +187,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -196,7 +196,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -264,7 +264,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -273,7 +273,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -338,7 +338,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -347,7 +347,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -415,7 +415,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -424,7 +424,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -498,7 +498,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -507,7 +507,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -576,7 +576,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -585,7 +585,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/IpSpaceApi.md
+++ b/src/ipam/docs/IpSpaceApi.md
@@ -36,17 +36,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.IpSpaceApi(api_client)
     body = ipam.BulkCopyIPSpace() # BulkCopyIPSpace | 
@@ -112,17 +112,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.IpSpaceApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -190,17 +190,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.IpSpaceApi(api_client)
     body = ipam.IPSpace() # IPSpace | 
@@ -267,17 +267,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.IpSpaceApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -341,17 +341,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.IpSpaceApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -418,17 +418,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.IpSpaceApi(api_client)
 
@@ -501,17 +501,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.IpSpaceApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -579,17 +579,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.IpSpaceApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/docs/IpamHostApi.md
+++ b/src/ipam/docs/IpamHostApi.md
@@ -30,7 +30,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -262,7 +262,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -271,7 +271,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -340,7 +340,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -349,7 +349,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/IpamHostApi.md
+++ b/src/ipam/docs/IpamHostApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.IpamHostApi(api_client)
     body = ipam.IpamHost() # IpamHost | 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.IpamHostApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.IpamHostApi(api_client)
 
@@ -265,17 +265,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.IpamHostApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -343,17 +343,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.IpamHostApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/docs/LeasesCommandApi.md
+++ b/src/ipam/docs/LeasesCommandApi.md
@@ -29,17 +29,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.LeasesCommandApi(api_client)
     body = ipam.LeasesCommand() # LeasesCommand | 

--- a/src/ipam/docs/LeasesCommandApi.md
+++ b/src/ipam/docs/LeasesCommandApi.md
@@ -26,7 +26,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -35,7 +35,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/MacAddressItemApi.md
+++ b/src/ipam/docs/MacAddressItemApi.md
@@ -32,7 +32,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -41,7 +41,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -108,7 +108,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -117,7 +117,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -184,7 +184,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -193,7 +193,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -258,7 +258,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -267,7 +267,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -338,7 +338,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -347,7 +347,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -415,7 +415,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -424,7 +424,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -493,7 +493,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -502,7 +502,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/MacAddressItemApi.md
+++ b/src/ipam/docs/MacAddressItemApi.md
@@ -35,17 +35,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.MacAddressItemApi(api_client)
     body = ipam.BulkMacAddressItem() # BulkMacAddressItem | 
@@ -111,17 +111,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.MacAddressItemApi(api_client)
     body = ipam.MacAddressItem() # MacAddressItem | 
@@ -187,17 +187,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.MacAddressItemApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -261,17 +261,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.MacAddressItemApi(api_client)
 
@@ -341,17 +341,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.MacAddressItemApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -418,17 +418,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.MacAddressItemApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -496,17 +496,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.MacAddressItemApi(api_client)
     body = ipam.MacAddressItemUpload() # MacAddressItemUpload | 

--- a/src/ipam/docs/OptionCodeApi.md
+++ b/src/ipam/docs/OptionCodeApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionCodeApi(api_client)
     body = ipam.OptionCode() # OptionCode | 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionCodeApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionCodeApi(api_client)
 
@@ -263,17 +263,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionCodeApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -340,17 +340,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionCodeApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/docs/OptionCodeApi.md
+++ b/src/ipam/docs/OptionCodeApi.md
@@ -30,7 +30,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -260,7 +260,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -269,7 +269,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -337,7 +337,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -346,7 +346,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/OptionFilterApi.md
+++ b/src/ipam/docs/OptionFilterApi.md
@@ -30,7 +30,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -262,7 +262,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -271,7 +271,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -339,7 +339,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -348,7 +348,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/OptionFilterApi.md
+++ b/src/ipam/docs/OptionFilterApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionFilterApi(api_client)
     body = ipam.OptionFilter() # OptionFilter | 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionFilterApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionFilterApi(api_client)
 
@@ -265,17 +265,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionFilterApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -342,17 +342,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionFilterApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/docs/OptionGroupApi.md
+++ b/src/ipam/docs/OptionGroupApi.md
@@ -30,7 +30,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -262,7 +262,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -271,7 +271,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -339,7 +339,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -348,7 +348,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/OptionGroupApi.md
+++ b/src/ipam/docs/OptionGroupApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionGroupApi(api_client)
     body = ipam.OptionGroup() # OptionGroup | 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionGroupApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionGroupApi(api_client)
 
@@ -265,17 +265,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionGroupApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -342,17 +342,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionGroupApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/docs/OptionSpaceApi.md
+++ b/src/ipam/docs/OptionSpaceApi.md
@@ -30,7 +30,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -262,7 +262,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -271,7 +271,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -339,7 +339,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -348,7 +348,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/OptionSpaceApi.md
+++ b/src/ipam/docs/OptionSpaceApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionSpaceApi(api_client)
     body = ipam.OptionSpace() # OptionSpace | 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionSpaceApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionSpaceApi(api_client)
 
@@ -265,17 +265,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionSpaceApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -342,17 +342,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.OptionSpaceApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/docs/RangeApi.md
+++ b/src/ipam/docs/RangeApi.md
@@ -35,17 +35,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.RangeApi(api_client)
     body = ipam.Range() # Range | 
@@ -112,17 +112,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.RangeApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -190,17 +190,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.RangeApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -264,17 +264,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.RangeApi(api_client)
 
@@ -347,17 +347,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.RangeApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -425,17 +425,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.RangeApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -503,17 +503,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.RangeApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/docs/RangeApi.md
+++ b/src/ipam/docs/RangeApi.md
@@ -32,7 +32,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -41,7 +41,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -109,7 +109,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -118,7 +118,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -187,7 +187,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -196,7 +196,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -261,7 +261,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -270,7 +270,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -344,7 +344,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -353,7 +353,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -422,7 +422,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -431,7 +431,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -500,7 +500,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -509,7 +509,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/ServerApi.md
+++ b/src/ipam/docs/ServerApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.ServerApi(api_client)
     body = ipam.Server() # Server | 
@@ -110,17 +110,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.ServerApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -184,17 +184,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.ServerApi(api_client)
 
@@ -267,17 +267,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.ServerApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -345,17 +345,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.ServerApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/docs/ServerApi.md
+++ b/src/ipam/docs/ServerApi.md
@@ -30,7 +30,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -107,7 +107,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -116,7 +116,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -181,7 +181,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -190,7 +190,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -264,7 +264,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -273,7 +273,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -342,7 +342,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -351,7 +351,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/ServiceApi.md
+++ b/src/ipam/docs/ServiceApi.md
@@ -27,7 +27,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -36,7 +36,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -109,7 +109,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -118,7 +118,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/ServiceApi.md
+++ b/src/ipam/docs/ServiceApi.md
@@ -30,17 +30,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.ServiceApi(api_client)
 
@@ -112,17 +112,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.ServiceApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/docs/SubnetApi.md
+++ b/src/ipam/docs/SubnetApi.md
@@ -34,7 +34,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -43,7 +43,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -112,7 +112,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -121,7 +121,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -189,7 +189,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -198,7 +198,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -267,7 +267,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -276,7 +276,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -341,7 +341,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -350,7 +350,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -424,7 +424,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -433,7 +433,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -501,7 +501,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -510,7 +510,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -579,7 +579,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -588,7 +588,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -657,7 +657,7 @@ import ipam
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -666,7 +666,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam/docs/SubnetApi.md
+++ b/src/ipam/docs/SubnetApi.md
@@ -37,17 +37,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.SubnetApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -115,17 +115,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.SubnetApi(api_client)
     body = ipam.Subnet() # Subnet | 
@@ -192,17 +192,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.SubnetApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -270,17 +270,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.SubnetApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -344,17 +344,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.SubnetApi(api_client)
 
@@ -427,17 +427,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.SubnetApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -504,17 +504,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.SubnetApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -582,17 +582,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.SubnetApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -660,17 +660,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam.SubnetApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam/models/address.py
+++ b/src/ipam/models/address.py
@@ -29,7 +29,8 @@ class Address(BaseModel):
     """
     An __Address__ object (_ipam/address_) represents any single IP address within a given IP space.
     """ # noqa: E501
-    address: StrictStr = Field(description="The address in form \"a.b.c.d\".")
+    address: Optional[StrictStr] = Field(
+        default=None, description="The address in form \"a.b.c.d\".")
     comment: Optional[StrictStr] = Field(
         default=None,
         description=

--- a/src/ipam_federation/README.md
+++ b/src/ipam_federation/README.md
@@ -29,11 +29,11 @@ you can run the following:
 
 ```python
 
-import ipam_federation
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"import ipam_federation
 from ipam_federation.rest import ApiException
 from pprint import pprint
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -42,7 +42,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 

--- a/src/ipam_federation/README.md
+++ b/src/ipam_federation/README.md
@@ -36,14 +36,14 @@ from pprint import pprint
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 
 # Enter a context with an instance of the API client

--- a/src/ipam_federation/docs/FederatedBlockApi.md
+++ b/src/ipam_federation/docs/FederatedBlockApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.FederatedBlockApi(api_client)
     body = ipam_federation.FederatedBlock() # FederatedBlock | 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.FederatedBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.FederatedBlockApi(api_client)
 
@@ -265,17 +265,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.FederatedBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -342,17 +342,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.FederatedBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam_federation/docs/FederatedBlockApi.md
+++ b/src/ipam_federation/docs/FederatedBlockApi.md
@@ -30,7 +30,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -262,7 +262,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -271,7 +271,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -339,7 +339,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -348,7 +348,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam_federation/docs/FederatedRealmApi.md
+++ b/src/ipam_federation/docs/FederatedRealmApi.md
@@ -30,7 +30,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -262,7 +262,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -271,7 +271,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -339,7 +339,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -348,7 +348,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam_federation/docs/FederatedRealmApi.md
+++ b/src/ipam_federation/docs/FederatedRealmApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.FederatedRealmApi(api_client)
     body = ipam_federation.FederatedRealm() # FederatedRealm | 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.FederatedRealmApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.FederatedRealmApi(api_client)
 
@@ -265,17 +265,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.FederatedRealmApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -342,17 +342,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.FederatedRealmApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam_federation/docs/NextAvailableFederatedBlockApi.md
+++ b/src/ipam_federation/docs/NextAvailableFederatedBlockApi.md
@@ -32,17 +32,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.NextAvailableFederatedBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -110,17 +110,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.NextAvailableFederatedBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -188,17 +188,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.NextAvailableFederatedBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -266,17 +266,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.NextAvailableFederatedBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam_federation/docs/NextAvailableFederatedBlockApi.md
+++ b/src/ipam_federation/docs/NextAvailableFederatedBlockApi.md
@@ -29,7 +29,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -38,7 +38,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -107,7 +107,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -116,7 +116,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -185,7 +185,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -194,7 +194,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -263,7 +263,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -272,7 +272,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam_federation/docs/NextAvailableOverlappingBlockApi.md
+++ b/src/ipam_federation/docs/NextAvailableOverlappingBlockApi.md
@@ -26,7 +26,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -35,7 +35,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam_federation/docs/NextAvailableOverlappingBlockApi.md
+++ b/src/ipam_federation/docs/NextAvailableOverlappingBlockApi.md
@@ -29,17 +29,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.NextAvailableOverlappingBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam_federation/docs/NextAvailableReservedBlockApi.md
+++ b/src/ipam_federation/docs/NextAvailableReservedBlockApi.md
@@ -26,7 +26,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -35,7 +35,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam_federation/docs/NextAvailableReservedBlockApi.md
+++ b/src/ipam_federation/docs/NextAvailableReservedBlockApi.md
@@ -29,17 +29,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.NextAvailableReservedBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam_federation/docs/OverlappingBlockApi.md
+++ b/src/ipam_federation/docs/OverlappingBlockApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.OverlappingBlockApi(api_client)
     body = ipam_federation.OverlappingBlock() # OverlappingBlock | 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.OverlappingBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.OverlappingBlockApi(api_client)
 
@@ -265,17 +265,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.OverlappingBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -342,17 +342,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.OverlappingBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/ipam_federation/docs/OverlappingBlockApi.md
+++ b/src/ipam_federation/docs/OverlappingBlockApi.md
@@ -30,7 +30,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -262,7 +262,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -271,7 +271,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -339,7 +339,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -348,7 +348,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam_federation/docs/ReservedBlockApi.md
+++ b/src/ipam_federation/docs/ReservedBlockApi.md
@@ -30,7 +30,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -262,7 +262,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -271,7 +271,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -339,7 +339,7 @@ import ipam_federation
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -348,7 +348,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/ipam_federation/docs/ReservedBlockApi.md
+++ b/src/ipam_federation/docs/ReservedBlockApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.ReservedBlockApi(api_client)
     body = ipam_federation.ReservedBlock() # ReservedBlock | 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.ReservedBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.ReservedBlockApi(api_client)
 
@@ -265,17 +265,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.ReservedBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -342,17 +342,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ipam_federation.ReservedBlockApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/keys/README.md
+++ b/src/keys/README.md
@@ -36,14 +36,14 @@ from pprint import pprint
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 
 # Enter a context with an instance of the API client

--- a/src/keys/README.md
+++ b/src/keys/README.md
@@ -33,7 +33,7 @@ import keys
 from keys.rest import ApiException
 from pprint import pprint
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -42,7 +42,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 

--- a/src/keys/docs/GenerateTsigApi.md
+++ b/src/keys/docs/GenerateTsigApi.md
@@ -26,7 +26,7 @@ import keys
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -35,7 +35,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/keys/docs/GenerateTsigApi.md
+++ b/src/keys/docs/GenerateTsigApi.md
@@ -29,17 +29,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = keys.GenerateTsigApi(api_client)
 

--- a/src/keys/docs/KerberosApi.md
+++ b/src/keys/docs/KerberosApi.md
@@ -32,17 +32,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = keys.KerberosApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -106,17 +106,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = keys.KerberosApi(api_client)
 
@@ -188,17 +188,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = keys.KerberosApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -265,17 +265,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = keys.KerberosApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/keys/docs/KerberosApi.md
+++ b/src/keys/docs/KerberosApi.md
@@ -29,7 +29,7 @@ import keys
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -38,7 +38,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -103,7 +103,7 @@ import keys
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -112,7 +112,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -185,7 +185,7 @@ import keys
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -194,7 +194,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -262,7 +262,7 @@ import keys
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -271,7 +271,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/keys/docs/TsigApi.md
+++ b/src/keys/docs/TsigApi.md
@@ -30,7 +30,7 @@ import keys
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -106,7 +106,7 @@ import keys
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -115,7 +115,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -180,7 +180,7 @@ import keys
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -189,7 +189,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -262,7 +262,7 @@ import keys
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -271,7 +271,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -339,7 +339,7 @@ import keys
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -348,7 +348,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/keys/docs/TsigApi.md
+++ b/src/keys/docs/TsigApi.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = keys.TsigApi(api_client)
     body = keys.TSIGKey() # TSIGKey | 
@@ -109,17 +109,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = keys.TsigApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -183,17 +183,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = keys.TsigApi(api_client)
 
@@ -265,17 +265,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = keys.TsigApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource
@@ -342,17 +342,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = keys.TsigApi(api_client)
     id = 'id_example' # str | An application specific resource identity of a resource

--- a/src/keys/docs/UploadApi.md
+++ b/src/keys/docs/UploadApi.md
@@ -26,7 +26,7 @@ import keys
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -35,7 +35,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/keys/docs/UploadApi.md
+++ b/src/keys/docs/UploadApi.md
@@ -29,17 +29,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = keys.UploadApi(api_client)
     body = keys.UploadRequest() # UploadRequest | 

--- a/src/redirect/README.md
+++ b/src/redirect/README.md
@@ -33,7 +33,7 @@ import redirect
 from redirect.rest import ApiException
 from pprint import pprint
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/redirect/README.md
+++ b/src/redirect/README.md
@@ -36,7 +36,7 @@ from pprint import pprint
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 

--- a/src/redirect/docs/CertificateApi.md
+++ b/src/redirect/docs/CertificateApi.md
@@ -28,12 +28,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = redirect.CertificateApi(api_client)
 

--- a/src/redirect/docs/CertificateApi.md
+++ b/src/redirect/docs/CertificateApi.md
@@ -25,7 +25,7 @@ import redirect
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/redirect/docs/CustomRedirectsApi.md
+++ b/src/redirect/docs/CustomRedirectsApi.md
@@ -33,12 +33,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = redirect.CustomRedirectsApi(api_client)
     body = redirect.CustomRedirect() # CustomRedirect | The Custom Redirect object.
@@ -106,12 +106,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = redirect.CustomRedirectsApi(api_client)
     body = redirect.CustomRedirectDeleteRequest() # CustomRedirectDeleteRequest | 
@@ -176,12 +176,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = redirect.CustomRedirectsApi(api_client)
     id = 56 # int | The Custom Redirect object identifier.
@@ -246,12 +246,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = redirect.CustomRedirectsApi(api_client)
 
@@ -317,12 +317,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = redirect.CustomRedirectsApi(api_client)
     id = 56 # int | The Custom Redirect object identifier.
@@ -391,12 +391,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = redirect.CustomRedirectsApi(api_client)
     id = 56 # int | The Custom Redirect object identifier.

--- a/src/redirect/docs/CustomRedirectsApi.md
+++ b/src/redirect/docs/CustomRedirectsApi.md
@@ -30,7 +30,7 @@ import redirect
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -103,7 +103,7 @@ import redirect
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -173,7 +173,7 @@ import redirect
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -243,7 +243,7 @@ import redirect
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -314,7 +314,7 @@ import redirect
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -388,7 +388,7 @@ import redirect
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/redirect/docs/RedirectPageApi.md
+++ b/src/redirect/docs/RedirectPageApi.md
@@ -29,12 +29,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = redirect.RedirectPageApi(api_client)
 
@@ -100,12 +100,12 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = redirect.RedirectPageApi(api_client)
     body = redirect.UpdateRedirectPagePayload() # UpdateRedirectPagePayload | The Redirect Page object.

--- a/src/redirect/docs/RedirectPageApi.md
+++ b/src/redirect/docs/RedirectPageApi.md
@@ -26,7 +26,7 @@ import redirect
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -97,7 +97,7 @@ import redirect
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),

--- a/src/universal_ddi_client/api_client.py
+++ b/src/universal_ddi_client/api_client.py
@@ -229,7 +229,7 @@ class ApiClient:
 
         # request url
         if _host is None:
-            url = self.configuration.csp_url + base_path + resource_path
+            url = self.configuration.portal_url + base_path + resource_path
         else:
             # use server/host defined in path or operation instead
             url = _host + resource_path
@@ -550,7 +550,7 @@ class ApiClient:
         :param headers: Header parameters dict to be updated.
         """
         headers['Authorization'] = "Token {}".format(
-            self.configuration.api_key)
+            self.configuration.portal_key)
 
     def update_infoblox_headers(
             self,

--- a/src/universal_ddi_client/api_client_test.py
+++ b/src/universal_ddi_client/api_client_test.py
@@ -13,7 +13,7 @@ class TestApiClient(unittest.TestCase):
 
     def test_default_client(self):
         self.assertIsNotNone(self.api_client.configuration)
-        self.assertEqual(self.api_client.configuration.csp_url,
+        self.assertEqual(self.api_client.configuration.portal_url,
                          'https://csp.infoblox.com')
         self.assertEqual(self.api_client.configuration.client_name,
                          'universal-ddi-python-client')

--- a/src/universal_ddi_client/configuration.py
+++ b/src/universal_ddi_client/configuration.py
@@ -18,10 +18,10 @@ JSON_SCHEMA_VALIDATION_KEYWORDS = {
 class Configuration:
     """This class contains various settings of the API client.
 
-    :param csp_url: URL for Infoblox Cloud Services Portal.
+    :param portal_url: URL for Infoblox Cloud Services Portal.
       Can also be configured using the `INFOBLOX_PORTAL_URL` environment variable.
       Default is `https://csp.infoblox.com`.
-    :param api_key: API Key for accessing the Infoblox API.
+    :param portal_key: API Key for accessing the Infoblox API.
       Can also be configured by using the `INFOBLOX_PORTAL_KEY` environment variable.
 
       You can configure an API key for your user account in the Infoblox Cloud Services Portal.
@@ -36,35 +36,35 @@ class Configuration:
 
     API Key Authentication Example.
 conf = ipam.Configuration(
-    api_key='your_api_key'
+    portal_key='your_portal_key'
 )
 
     The following header will be added to the HTTP request:
-       Authorization: Token your_api_key
+       Authorization: Token your_portal_key
     """
 
     _default = None
 
     def __init__(
         self,
-        csp_url=None,
-        api_key=None,
+        portal_url=None,
+        portal_key=None,
         client_name=None,
         ssl_ca_cert=None,
     ) -> None:
         """Constructor
         """
 
-        self.csp_url = csp_url or os.getenv("INFOBLOX_PORTAL_URL") or os.getenv("BLOXONE_CSP_URL") or "https://csp.infoblox.com"
+        self.portal_url = portal_url or os.getenv("INFOBLOX_PORTAL_URL") or os.getenv("BLOXONE_CSP_URL") or "https://csp.infoblox.com"
         """Default CSP url
         """
         self.temp_folder_path = None
         """Temp file folder for downloading files
         """
         # Authentication Settings
-        self.api_key = os.getenv('INFOBLOX_PORTAL_KEY') or os.getenv('BLOXONE_API_KEY') or ""
-        if api_key:
-            self.api_key = api_key
+        self.portal_key = os.getenv('INFOBLOX_PORTAL_KEY') or os.getenv('BLOXONE_API_KEY') or ""
+        if portal_key:
+            self.portal_key = portal_key
         """API Key
         """
         self.client_name = "universal-ddi-python-client" if client_name is None else client_name
@@ -289,36 +289,36 @@ conf = ipam.Configuration(
                format(env=sys.platform, pyversion=sys.version)
 
     @property
-    def csp_url(self):
+    def portal_url(self):
         """Get the CSP URL.
 
         :return: The CSP URL.
         """
-        return self.__csp_url
+        return self.__portal_url
 
-    @csp_url.setter
-    def csp_url(self, value):
+    @portal_url.setter
+    def portal_url(self, value):
         """Set the CSP URL.
 
         :param value: The CSP URL.
         """
-        self.__csp_url = value
+        self.__portal_url = value
 
     @property
-    def api_key(self):
+    def portal_key(self):
         """Get the API key.
 
         :return: The API key.
         """
-        return self.__api_key
+        return self.__portal_key
 
-    @api_key.setter
-    def api_key(self, value):
+    @portal_key.setter
+    def portal_key(self, value):
         """Set the API key.
 
         :param value: The API key.
         """
-        self.__api_key = value
+        self.__portal_key = value
 
     @property
     def client_name(self):

--- a/src/universal_ddi_client/configuration.py
+++ b/src/universal_ddi_client/configuration.py
@@ -55,14 +55,14 @@ conf = ipam.Configuration(
         """Constructor
         """
 
-        self.csp_url = os.getenv('INFOBLOX_PORTAL_URL', "https://csp.infoblox.com") if csp_url is None else csp_url
+        self.csp_url = csp_url or os.getenv("INFOBLOX_PORTAL_URL") or os.getenv("BLOXONE_CSP_URL") or "https://csp.infoblox.com"
         """Default CSP url
         """
         self.temp_folder_path = None
         """Temp file folder for downloading files
         """
         # Authentication Settings
-        self.api_key = os.getenv('INFOBLOX_PORTAL_KEY', "")
+        self.api_key = os.getenv('INFOBLOX_PORTAL_KEY') or os.getenv('BLOXONE_API_KEY') or ""
         if api_key:
             self.api_key = api_key
         """API Key

--- a/src/upgrade_policy/README.md
+++ b/src/upgrade_policy/README.md
@@ -36,14 +36,14 @@ from pprint import pprint
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 
 # Enter a context with an instance of the API client

--- a/src/upgrade_policy/README.md
+++ b/src/upgrade_policy/README.md
@@ -33,7 +33,7 @@ import upgrade_policy
 from upgrade_policy.rest import ApiException
 from pprint import pprint
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -42,7 +42,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 

--- a/src/upgrade_policy/docs/UpgradePolicyV2Api.md
+++ b/src/upgrade_policy/docs/UpgradePolicyV2Api.md
@@ -30,7 +30,7 @@ import upgrade_policy
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -39,7 +39,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -104,7 +104,7 @@ import upgrade_policy
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -113,7 +113,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -178,7 +178,7 @@ import upgrade_policy
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -187,7 +187,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -252,7 +252,7 @@ import upgrade_policy
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -261,7 +261,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -326,7 +326,7 @@ import upgrade_policy
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -335,7 +335,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -400,7 +400,7 @@ import upgrade_policy
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -409,7 +409,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
@@ -473,7 +473,7 @@ import upgrade_policy
 from universal_ddi_client.api_client import ApiClient
 from universal_ddi_client.configuration import Configuration
 
-# Defining the CSP URL is optional and defaults to "https://csp.infoblox.com"
+# Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
     csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
@@ -482,7 +482,7 @@ configuration = Configuration(
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
-# Configure API key authorization: ApiKeyAuth
+# Configure Portal key authorization: ApiKeyAuth
 configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client

--- a/src/upgrade_policy/docs/UpgradePolicyV2Api.md
+++ b/src/upgrade_policy/docs/UpgradePolicyV2Api.md
@@ -33,17 +33,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = upgrade_policy.UpgradePolicyV2Api(api_client)
     body = upgrade_policy.ApplyConfigNowRequest() # ApplyConfigNowRequest | 
@@ -107,17 +107,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = upgrade_policy.UpgradePolicyV2Api(api_client)
     body = upgrade_policy.BatchMaintenanceWindowRequest() # BatchMaintenanceWindowRequest | 
@@ -181,17 +181,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = upgrade_policy.UpgradePolicyV2Api(api_client)
     body = upgrade_policy.CreateMaintenanceWindowRequest() # CreateMaintenanceWindowRequest | 
@@ -255,17 +255,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = upgrade_policy.UpgradePolicyV2Api(api_client)
     id = 'id_example' # str | uuid of a maintenance window record
@@ -329,17 +329,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = upgrade_policy.UpgradePolicyV2Api(api_client)
     id = 'id_example' # str | uuid of a maintenance window record
@@ -403,17 +403,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = upgrade_policy.UpgradePolicyV2Api(api_client)
 
@@ -476,17 +476,17 @@ from universal_ddi_client.configuration import Configuration
 # Defining the Portal URL is optional and defaults to "https://csp.infoblox.com"
 # See configuration.py for a list of all supported configuration parameters.
 configuration = Configuration(
-    csp_url = os.getenv('INFOBLOX_PORTAL_URL'),
+    portal_url = os.getenv('INFOBLOX_PORTAL_URL'),
 )
 
 # The client must configure the authentication and authorization parameters
 # in accordance with the API server security policy.
 
 # Configure Portal key authorization: ApiKeyAuth
-configuration.api_key = os.getenv("INFOBLOX_PORTAL_KEY")
+configuration.portal_key = os.getenv("INFOBLOX_PORTAL_KEY")
 
 # Enter a context with an instance of the API client
-with ApiClient(config) as api_client:
+with ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = upgrade_policy.UpgradePolicyV2Api(api_client)
     id = 'id_example' # str | uuid of a maintenance window record


### PR DESCRIPTION
This PR contains : 

- Updated Configuration to support `BLOXONE_CSP_URL` and `BLOXONE_API_KEY` along with new env variables.
- Updated Read me to accomodate the change
- Updated Descriptions for Authorization Code
- Made `address` as optional variable in IPAM Address Model (change was made previously but reverted by mistake in previous PR )
- removed absolute_name from read only from dns_host