### PR TITLE
Minor Fix to Source Configs in Cloud Discovery

### DIFF
--- a/src/cloud_discovery/docs/SourceConfig.md
+++ b/src/cloud_discovery/docs/SourceConfig.md
@@ -12,7 +12,7 @@ Name | Type | Description | Notes
 **created_at** | **datetime** | Timestamp when the object has been created. | [optional] [readonly] 
 **credential_config** | [**CredentialConfig**](CredentialConfig.md) | Credential configuration. Ex.: &#39;{    \&quot;access_identifier\&quot;: \&quot;arn:aws:iam::1234:role/access_for_discovery\&quot;,    \&quot;region\&quot;: \&quot;us-east-1\&quot;,    \&quot;enclave\&quot;: \&quot;commercial/gov\&quot;  }&#39;. | [optional] 
 **deleted_at** | **datetime** | Timestamp when the object has been deleted. | [optional] [readonly] 
-**id** | **str** | Auto-generated unique source config ID. Format BloxID. | [optional] [readonly] 
+**id** | **str** | Auto-generated unique source config ID. Format BloxID. | [optional] 
 **restricted_to_accounts** | **List[str]** | Provider account IDs such as accountID/ SubscriptionID to be restricted for a given source_config. | [optional] 
 **updated_at** | **datetime** | Timestamp when the object has been updated. | [optional] [readonly] 
 

--- a/src/cloud_discovery/models/source_config.py
+++ b/src/cloud_discovery/models/source_config.py
@@ -105,7 +105,6 @@ class SourceConfig(BaseModel):
             "account_schedule_id",
             "created_at",
             "deleted_at",
-            "id",
             "updated_at",
             "additional_properties",
         ])

--- a/src/cloud_discovery/models/source_config.py
+++ b/src/cloud_discovery/models/source_config.py
@@ -98,7 +98,6 @@ class SourceConfig(BaseModel):
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
-        * OpenAPI `readOnly` fields are excluded.
         * Fields in `self.additional_properties` are added to the output dict.
         """
         excluded_fields: Set[str] = set([


### PR DESCRIPTION
Removed ID as a readonly parameter from Source Configs in Cloud Discovery object group .