### PR TITLE
Added inheritance support for DTC objects for python-client 

### DIFF
--- a/src/dtc/api/policy_api.py
+++ b/src/dtc/api/policy_api.py
@@ -49,9 +49,10 @@ class PolicyApi:
         body: Policy,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -69,7 +70,7 @@ class PolicyApi:
 
         :param body: (required)
         :type body: Policy
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -118,9 +119,10 @@ class PolicyApi:
         body: Policy,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -138,7 +140,7 @@ class PolicyApi:
 
         :param body: (required)
         :type body: Policy
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -187,9 +189,10 @@ class PolicyApi:
         body: Policy,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -207,7 +210,7 @@ class PolicyApi:
 
         :param body: (required)
         :type body: Policy
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -592,9 +595,10 @@ class PolicyApi:
                   )] = None,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -626,7 +630,7 @@ class PolicyApi:
         :type tfilter: str
         :param torder_by: This parameter is used for sorting by tags.
         :type torder_by: str
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -725,9 +729,10 @@ class PolicyApi:
                   )] = None,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -759,7 +764,7 @@ class PolicyApi:
         :type tfilter: str
         :param torder_by: This parameter is used for sorting by tags.
         :type torder_by: str
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -858,9 +863,10 @@ class PolicyApi:
                   )] = None,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -892,7 +898,7 @@ class PolicyApi:
         :type tfilter: str
         :param torder_by: This parameter is used for sorting by tags.
         :type torder_by: str
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1044,9 +1050,10 @@ class PolicyApi:
             )] = None,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1066,7 +1073,7 @@ class PolicyApi:
         :type id: str
         :param fields:   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        
         :type fields: str
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1125,9 +1132,10 @@ class PolicyApi:
             )] = None,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1147,7 +1155,7 @@ class PolicyApi:
         :type id: str
         :param fields:   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        
         :type fields: str
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1206,9 +1214,10 @@ class PolicyApi:
             )] = None,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1228,7 +1237,7 @@ class PolicyApi:
         :type id: str
         :param fields:   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        
         :type fields: str
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1337,9 +1346,10 @@ class PolicyApi:
         body: Policy,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1359,7 +1369,7 @@ class PolicyApi:
         :type id: str
         :param body: (required)
         :type body: Policy
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1413,9 +1423,10 @@ class PolicyApi:
         body: Policy,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1435,7 +1446,7 @@ class PolicyApi:
         :type id: str
         :param body: (required)
         :type body: Policy
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1489,9 +1500,10 @@ class PolicyApi:
         body: Policy,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1511,7 +1523,7 @@ class PolicyApi:
         :type id: str
         :param body: (required)
         :type body: Policy
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request

--- a/src/dtc/api/policy_api.py
+++ b/src/dtc/api/policy_api.py
@@ -47,6 +47,11 @@ class PolicyApi:
     def create(
         self,
         body: Policy,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -64,6 +69,8 @@ class PolicyApi:
 
         :param body: (required)
         :type body: Policy
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -87,6 +94,7 @@ class PolicyApi:
         """ # noqa: E501
 
         _param = self._create_serialize(body=body,
+                                        inherit=inherit,
                                         _request_auth=_request_auth,
                                         _content_type=_content_type,
                                         _headers=_headers,
@@ -108,6 +116,11 @@ class PolicyApi:
     def create_with_http_info(
         self,
         body: Policy,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -125,6 +138,8 @@ class PolicyApi:
 
         :param body: (required)
         :type body: Policy
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -148,6 +163,7 @@ class PolicyApi:
         """ # noqa: E501
 
         _param = self._create_serialize(body=body,
+                                        inherit=inherit,
                                         _request_auth=_request_auth,
                                         _content_type=_content_type,
                                         _headers=_headers,
@@ -169,6 +185,11 @@ class PolicyApi:
     def create_without_preload_content(
         self,
         body: Policy,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -186,6 +207,8 @@ class PolicyApi:
 
         :param body: (required)
         :type body: Policy
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -209,6 +232,7 @@ class PolicyApi:
         """ # noqa: E501
 
         _param = self._create_serialize(body=body,
+                                        inherit=inherit,
                                         _request_auth=_request_auth,
                                         _content_type=_content_type,
                                         _headers=_headers,
@@ -224,6 +248,7 @@ class PolicyApi:
     def _create_serialize(
         self,
         body,
+        inherit,
         _request_auth,
         _content_type,
         _headers,
@@ -243,6 +268,10 @@ class PolicyApi:
 
         # process the path parameters
         # process the query parameters
+        if inherit is not None:
+
+            _query_params.append(('_inherit', inherit))
+
         # process the header parameters
         # process the form parameters
         # process the body parameter
@@ -561,6 +590,11 @@ class PolicyApi:
             Optional[StrictStr],
             Field(description="This parameter is used for sorting by tags."
                   )] = None,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -592,6 +626,8 @@ class PolicyApi:
         :type tfilter: str
         :param torder_by: This parameter is used for sorting by tags.
         :type torder_by: str
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -622,6 +658,7 @@ class PolicyApi:
                                       order_by=order_by,
                                       tfilter=tfilter,
                                       torder_by=torder_by,
+                                      inherit=inherit,
                                       _request_auth=_request_auth,
                                       _content_type=_content_type,
                                       _headers=_headers,
@@ -686,6 +723,11 @@ class PolicyApi:
             Optional[StrictStr],
             Field(description="This parameter is used for sorting by tags."
                   )] = None,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -717,6 +759,8 @@ class PolicyApi:
         :type tfilter: str
         :param torder_by: This parameter is used for sorting by tags.
         :type torder_by: str
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -747,6 +791,7 @@ class PolicyApi:
                                       order_by=order_by,
                                       tfilter=tfilter,
                                       torder_by=torder_by,
+                                      inherit=inherit,
                                       _request_auth=_request_auth,
                                       _content_type=_content_type,
                                       _headers=_headers,
@@ -811,6 +856,11 @@ class PolicyApi:
             Optional[StrictStr],
             Field(description="This parameter is used for sorting by tags."
                   )] = None,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -842,6 +892,8 @@ class PolicyApi:
         :type tfilter: str
         :param torder_by: This parameter is used for sorting by tags.
         :type torder_by: str
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -872,6 +924,7 @@ class PolicyApi:
                                       order_by=order_by,
                                       tfilter=tfilter,
                                       torder_by=torder_by,
+                                      inherit=inherit,
                                       _request_auth=_request_auth,
                                       _content_type=_content_type,
                                       _headers=_headers,
@@ -894,6 +947,7 @@ class PolicyApi:
         order_by,
         tfilter,
         torder_by,
+        inherit,
         _request_auth,
         _content_type,
         _headers,
@@ -945,6 +999,10 @@ class PolicyApi:
 
             _query_params.append(('_torder_by', torder_by))
 
+        if inherit is not None:
+
+            _query_params.append(('_inherit', inherit))
+
         # process the header parameters
         # process the form parameters
         # process the body parameter
@@ -984,6 +1042,11 @@ class PolicyApi:
                 description=
                 "  A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        "
             )] = None,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1003,6 +1066,8 @@ class PolicyApi:
         :type id: str
         :param fields:   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        
         :type fields: str
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1027,6 +1092,7 @@ class PolicyApi:
 
         _param = self._read_serialize(id=id,
                                       fields=fields,
+                                      inherit=inherit,
                                       _request_auth=_request_auth,
                                       _content_type=_content_type,
                                       _headers=_headers,
@@ -1057,6 +1123,11 @@ class PolicyApi:
                 description=
                 "  A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        "
             )] = None,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1076,6 +1147,8 @@ class PolicyApi:
         :type id: str
         :param fields:   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        
         :type fields: str
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1100,6 +1173,7 @@ class PolicyApi:
 
         _param = self._read_serialize(id=id,
                                       fields=fields,
+                                      inherit=inherit,
                                       _request_auth=_request_auth,
                                       _content_type=_content_type,
                                       _headers=_headers,
@@ -1130,6 +1204,11 @@ class PolicyApi:
                 description=
                 "  A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        "
             )] = None,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1149,6 +1228,8 @@ class PolicyApi:
         :type id: str
         :param fields:   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        
         :type fields: str
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1173,6 +1254,7 @@ class PolicyApi:
 
         _param = self._read_serialize(id=id,
                                       fields=fields,
+                                      inherit=inherit,
                                       _request_auth=_request_auth,
                                       _content_type=_content_type,
                                       _headers=_headers,
@@ -1189,6 +1271,7 @@ class PolicyApi:
         self,
         id,
         fields,
+        inherit,
         _request_auth,
         _content_type,
         _headers,
@@ -1213,6 +1296,10 @@ class PolicyApi:
         if fields is not None:
 
             _query_params.append(('_fields', fields))
+
+        if inherit is not None:
+
+            _query_params.append(('_inherit', inherit))
 
         # process the header parameters
         # process the form parameters
@@ -1248,6 +1335,11 @@ class PolicyApi:
             Field(description=
                   "An application specific resource identity of a resource")],
         body: Policy,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1267,6 +1359,8 @@ class PolicyApi:
         :type id: str
         :param body: (required)
         :type body: Policy
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1291,6 +1385,7 @@ class PolicyApi:
 
         _param = self._update_serialize(id=id,
                                         body=body,
+                                        inherit=inherit,
                                         _request_auth=_request_auth,
                                         _content_type=_content_type,
                                         _headers=_headers,
@@ -1316,6 +1411,11 @@ class PolicyApi:
             Field(description=
                   "An application specific resource identity of a resource")],
         body: Policy,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1335,6 +1435,8 @@ class PolicyApi:
         :type id: str
         :param body: (required)
         :type body: Policy
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1359,6 +1461,7 @@ class PolicyApi:
 
         _param = self._update_serialize(id=id,
                                         body=body,
+                                        inherit=inherit,
                                         _request_auth=_request_auth,
                                         _content_type=_content_type,
                                         _headers=_headers,
@@ -1384,6 +1487,11 @@ class PolicyApi:
             Field(description=
                   "An application specific resource identity of a resource")],
         body: Policy,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1403,6 +1511,8 @@ class PolicyApi:
         :type id: str
         :param body: (required)
         :type body: Policy
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1427,6 +1537,7 @@ class PolicyApi:
 
         _param = self._update_serialize(id=id,
                                         body=body,
+                                        inherit=inherit,
                                         _request_auth=_request_auth,
                                         _content_type=_content_type,
                                         _headers=_headers,
@@ -1443,6 +1554,7 @@ class PolicyApi:
         self,
         id,
         body,
+        inherit,
         _request_auth,
         _content_type,
         _headers,
@@ -1464,6 +1576,10 @@ class PolicyApi:
         if id is not None:
             _path_params['id'] = self.api_client.path_param_value('id', id)
         # process the query parameters
+        if inherit is not None:
+
+            _query_params.append(('_inherit', inherit))
+
         # process the header parameters
         # process the form parameters
         # process the body parameter

--- a/src/dtc/api/pool_api.py
+++ b/src/dtc/api/pool_api.py
@@ -49,9 +49,10 @@ class PoolApi:
         body: Pool,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -69,7 +70,7 @@ class PoolApi:
 
         :param body: (required)
         :type body: Pool
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -118,9 +119,10 @@ class PoolApi:
         body: Pool,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -138,7 +140,7 @@ class PoolApi:
 
         :param body: (required)
         :type body: Pool
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -187,9 +189,10 @@ class PoolApi:
         body: Pool,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -207,7 +210,7 @@ class PoolApi:
 
         :param body: (required)
         :type body: Pool
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -592,9 +595,10 @@ class PoolApi:
                   )] = None,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -626,7 +630,7 @@ class PoolApi:
         :type tfilter: str
         :param torder_by: This parameter is used for sorting by tags.
         :type torder_by: str
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -725,9 +729,10 @@ class PoolApi:
                   )] = None,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -759,7 +764,7 @@ class PoolApi:
         :type tfilter: str
         :param torder_by: This parameter is used for sorting by tags.
         :type torder_by: str
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -858,9 +863,10 @@ class PoolApi:
                   )] = None,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -892,7 +898,7 @@ class PoolApi:
         :type tfilter: str
         :param torder_by: This parameter is used for sorting by tags.
         :type torder_by: str
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1044,9 +1050,10 @@ class PoolApi:
             )] = None,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1066,7 +1073,7 @@ class PoolApi:
         :type id: str
         :param fields:   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        
         :type fields: str
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1125,9 +1132,10 @@ class PoolApi:
             )] = None,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1147,7 +1155,7 @@ class PoolApi:
         :type id: str
         :param fields:   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        
         :type fields: str
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1206,9 +1214,10 @@ class PoolApi:
             )] = None,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1228,7 +1237,7 @@ class PoolApi:
         :type id: str
         :param fields:   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        
         :type fields: str
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1337,9 +1346,10 @@ class PoolApi:
         body: Pool,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1359,7 +1369,7 @@ class PoolApi:
         :type id: str
         :param body: (required)
         :type body: Pool
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1413,9 +1423,10 @@ class PoolApi:
         body: Pool,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1435,7 +1446,7 @@ class PoolApi:
         :type id: str
         :param body: (required)
         :type body: Pool
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1489,9 +1500,10 @@ class PoolApi:
         body: Pool,
         inherit: Annotated[
             Optional[StrictStr],
-            Field(description=
-                  "This parameter is used for getting inheritance_sources."
-                  )] = None,
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1511,7 +1523,7 @@ class PoolApi:
         :type id: str
         :param body: (required)
         :type body: Pool
-        :param inherit: This parameter is used for getting inheritance_sources.
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
         :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request

--- a/src/dtc/api/pool_api.py
+++ b/src/dtc/api/pool_api.py
@@ -47,6 +47,11 @@ class PoolApi:
     def create(
         self,
         body: Pool,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -64,6 +69,8 @@ class PoolApi:
 
         :param body: (required)
         :type body: Pool
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -87,6 +94,7 @@ class PoolApi:
         """ # noqa: E501
 
         _param = self._create_serialize(body=body,
+                                        inherit=inherit,
                                         _request_auth=_request_auth,
                                         _content_type=_content_type,
                                         _headers=_headers,
@@ -108,6 +116,11 @@ class PoolApi:
     def create_with_http_info(
         self,
         body: Pool,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -125,6 +138,8 @@ class PoolApi:
 
         :param body: (required)
         :type body: Pool
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -148,6 +163,7 @@ class PoolApi:
         """ # noqa: E501
 
         _param = self._create_serialize(body=body,
+                                        inherit=inherit,
                                         _request_auth=_request_auth,
                                         _content_type=_content_type,
                                         _headers=_headers,
@@ -169,6 +185,11 @@ class PoolApi:
     def create_without_preload_content(
         self,
         body: Pool,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -186,6 +207,8 @@ class PoolApi:
 
         :param body: (required)
         :type body: Pool
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -209,6 +232,7 @@ class PoolApi:
         """ # noqa: E501
 
         _param = self._create_serialize(body=body,
+                                        inherit=inherit,
                                         _request_auth=_request_auth,
                                         _content_type=_content_type,
                                         _headers=_headers,
@@ -224,6 +248,7 @@ class PoolApi:
     def _create_serialize(
         self,
         body,
+        inherit,
         _request_auth,
         _content_type,
         _headers,
@@ -243,6 +268,10 @@ class PoolApi:
 
         # process the path parameters
         # process the query parameters
+        if inherit is not None:
+
+            _query_params.append(('_inherit', inherit))
+
         # process the header parameters
         # process the form parameters
         # process the body parameter
@@ -561,6 +590,11 @@ class PoolApi:
             Optional[StrictStr],
             Field(description="This parameter is used for sorting by tags."
                   )] = None,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -592,6 +626,8 @@ class PoolApi:
         :type tfilter: str
         :param torder_by: This parameter is used for sorting by tags.
         :type torder_by: str
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -622,6 +658,7 @@ class PoolApi:
                                       order_by=order_by,
                                       tfilter=tfilter,
                                       torder_by=torder_by,
+                                      inherit=inherit,
                                       _request_auth=_request_auth,
                                       _content_type=_content_type,
                                       _headers=_headers,
@@ -686,6 +723,11 @@ class PoolApi:
             Optional[StrictStr],
             Field(description="This parameter is used for sorting by tags."
                   )] = None,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -717,6 +759,8 @@ class PoolApi:
         :type tfilter: str
         :param torder_by: This parameter is used for sorting by tags.
         :type torder_by: str
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -747,6 +791,7 @@ class PoolApi:
                                       order_by=order_by,
                                       tfilter=tfilter,
                                       torder_by=torder_by,
+                                      inherit=inherit,
                                       _request_auth=_request_auth,
                                       _content_type=_content_type,
                                       _headers=_headers,
@@ -811,6 +856,11 @@ class PoolApi:
             Optional[StrictStr],
             Field(description="This parameter is used for sorting by tags."
                   )] = None,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -842,6 +892,8 @@ class PoolApi:
         :type tfilter: str
         :param torder_by: This parameter is used for sorting by tags.
         :type torder_by: str
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -872,6 +924,7 @@ class PoolApi:
                                       order_by=order_by,
                                       tfilter=tfilter,
                                       torder_by=torder_by,
+                                      inherit=inherit,
                                       _request_auth=_request_auth,
                                       _content_type=_content_type,
                                       _headers=_headers,
@@ -894,6 +947,7 @@ class PoolApi:
         order_by,
         tfilter,
         torder_by,
+        inherit,
         _request_auth,
         _content_type,
         _headers,
@@ -945,6 +999,10 @@ class PoolApi:
 
             _query_params.append(('_torder_by', torder_by))
 
+        if inherit is not None:
+
+            _query_params.append(('_inherit', inherit))
+
         # process the header parameters
         # process the form parameters
         # process the body parameter
@@ -984,6 +1042,11 @@ class PoolApi:
                 description=
                 "  A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        "
             )] = None,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1003,6 +1066,8 @@ class PoolApi:
         :type id: str
         :param fields:   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        
         :type fields: str
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1027,6 +1092,7 @@ class PoolApi:
 
         _param = self._read_serialize(id=id,
                                       fields=fields,
+                                      inherit=inherit,
                                       _request_auth=_request_auth,
                                       _content_type=_content_type,
                                       _headers=_headers,
@@ -1057,6 +1123,11 @@ class PoolApi:
                 description=
                 "  A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        "
             )] = None,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1076,6 +1147,8 @@ class PoolApi:
         :type id: str
         :param fields:   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        
         :type fields: str
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1100,6 +1173,7 @@ class PoolApi:
 
         _param = self._read_serialize(id=id,
                                       fields=fields,
+                                      inherit=inherit,
                                       _request_auth=_request_auth,
                                       _content_type=_content_type,
                                       _headers=_headers,
@@ -1130,6 +1204,11 @@ class PoolApi:
                 description=
                 "  A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        "
             )] = None,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1149,6 +1228,8 @@ class PoolApi:
         :type id: str
         :param fields:   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        
         :type fields: str
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1173,6 +1254,7 @@ class PoolApi:
 
         _param = self._read_serialize(id=id,
                                       fields=fields,
+                                      inherit=inherit,
                                       _request_auth=_request_auth,
                                       _content_type=_content_type,
                                       _headers=_headers,
@@ -1189,6 +1271,7 @@ class PoolApi:
         self,
         id,
         fields,
+        inherit,
         _request_auth,
         _content_type,
         _headers,
@@ -1213,6 +1296,10 @@ class PoolApi:
         if fields is not None:
 
             _query_params.append(('_fields', fields))
+
+        if inherit is not None:
+
+            _query_params.append(('_inherit', inherit))
 
         # process the header parameters
         # process the form parameters
@@ -1248,6 +1335,11 @@ class PoolApi:
             Field(description=
                   "An application specific resource identity of a resource")],
         body: Pool,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1267,6 +1359,8 @@ class PoolApi:
         :type id: str
         :param body: (required)
         :type body: Pool
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1291,6 +1385,7 @@ class PoolApi:
 
         _param = self._update_serialize(id=id,
                                         body=body,
+                                        inherit=inherit,
                                         _request_auth=_request_auth,
                                         _content_type=_content_type,
                                         _headers=_headers,
@@ -1316,6 +1411,11 @@ class PoolApi:
             Field(description=
                   "An application specific resource identity of a resource")],
         body: Pool,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1335,6 +1435,8 @@ class PoolApi:
         :type id: str
         :param body: (required)
         :type body: Pool
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1359,6 +1461,7 @@ class PoolApi:
 
         _param = self._update_serialize(id=id,
                                         body=body,
+                                        inherit=inherit,
                                         _request_auth=_request_auth,
                                         _content_type=_content_type,
                                         _headers=_headers,
@@ -1384,6 +1487,11 @@ class PoolApi:
             Field(description=
                   "An application specific resource identity of a resource")],
         body: Pool,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(description=
+                  "This parameter is used for getting inheritance_sources."
+                  )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1403,6 +1511,8 @@ class PoolApi:
         :type id: str
         :param body: (required)
         :type body: Pool
+        :param inherit: This parameter is used for getting inheritance_sources.
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1427,6 +1537,7 @@ class PoolApi:
 
         _param = self._update_serialize(id=id,
                                         body=body,
+                                        inherit=inherit,
                                         _request_auth=_request_auth,
                                         _content_type=_content_type,
                                         _headers=_headers,
@@ -1443,6 +1554,7 @@ class PoolApi:
         self,
         id,
         body,
+        inherit,
         _request_auth,
         _content_type,
         _headers,
@@ -1464,6 +1576,10 @@ class PoolApi:
         if id is not None:
             _path_params['id'] = self.api_client.path_param_value('id', id)
         # process the query parameters
+        if inherit is not None:
+
+            _query_params.append(('_inherit', inherit))
+
         # process the header parameters
         # process the form parameters
         # process the body parameter

--- a/src/dtc/docs/PolicyApi.md
+++ b/src/dtc/docs/PolicyApi.md
@@ -12,7 +12,7 @@ Method | HTTP request | Description
 
 
 # **create**
-> CreatePolicyResponse create(body)
+> CreatePolicyResponse create(body, inherit=inherit)
 
 Create the Policy object.
 
@@ -65,6 +65,7 @@ with ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **body** | [**Policy**](Policy.md)|  | 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources. | [optional] 
 
 ### Return type
 
@@ -162,7 +163,7 @@ void (empty response body)
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **list**
-> ListPolicyResponse list(fields=fields, filter=filter, offset=offset, limit=limit, page_token=page_token, order_by=order_by, tfilter=tfilter, torder_by=torder_by)
+> ListPolicyResponse list(fields=fields, filter=filter, offset=offset, limit=limit, page_token=page_token, order_by=order_by, tfilter=tfilter, torder_by=torder_by, inherit=inherit)
 
 Retrieve Policy objects.
 
@@ -221,6 +222,7 @@ Name | Type | Description  | Notes
  **order_by** | **str**|   A collection of response resources can be sorted by their JSON tags. For a &#39;flat&#39; resource, the tag name is straightforward. If sorting is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, its value is assumed to be null.)  Specify this parameter as a comma-separated list of JSON tag names. The sort direction can be specified by a suffix separated by whitespace before the tag name. The suffix &#39;asc&#39; sorts the data in ascending order. The suffix &#39;desc&#39; sorts the data in descending order. If no suffix is specified the data is sorted in ascending order.         | [optional] 
  **tfilter** | **str**| This parameter is used for filtering by tags. | [optional] 
  **torder_by** | **str**| This parameter is used for sorting by tags. | [optional] 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources. | [optional] 
 
 ### Return type
 
@@ -244,7 +246,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **read**
-> ReadPolicyResponse read(id, fields=fields)
+> ReadPolicyResponse read(id, fields=fields, inherit=inherit)
 
 Retrieve the Policy object.
 
@@ -298,6 +300,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **str**| An application specific resource identity of a resource | 
  **fields** | **str**|   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.         | [optional] 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources. | [optional] 
 
 ### Return type
 
@@ -321,7 +324,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **update**
-> UpdatePolicyResponse update(id, body)
+> UpdatePolicyResponse update(id, body, inherit=inherit)
 
 Update the Policy object.
 
@@ -376,6 +379,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **str**| An application specific resource identity of a resource | 
  **body** | [**Policy**](Policy.md)|  | 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources. | [optional] 
 
 ### Return type
 

--- a/src/dtc/docs/PolicyApi.md
+++ b/src/dtc/docs/PolicyApi.md
@@ -65,7 +65,7 @@ with ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **body** | [**Policy**](Policy.md)|  | 
- **inherit** | **str**| This parameter is used for getting inheritance_sources. | [optional] 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none | [optional] 
 
 ### Return type
 
@@ -222,7 +222,7 @@ Name | Type | Description  | Notes
  **order_by** | **str**|   A collection of response resources can be sorted by their JSON tags. For a &#39;flat&#39; resource, the tag name is straightforward. If sorting is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, its value is assumed to be null.)  Specify this parameter as a comma-separated list of JSON tag names. The sort direction can be specified by a suffix separated by whitespace before the tag name. The suffix &#39;asc&#39; sorts the data in ascending order. The suffix &#39;desc&#39; sorts the data in descending order. If no suffix is specified the data is sorted in ascending order.         | [optional] 
  **tfilter** | **str**| This parameter is used for filtering by tags. | [optional] 
  **torder_by** | **str**| This parameter is used for sorting by tags. | [optional] 
- **inherit** | **str**| This parameter is used for getting inheritance_sources. | [optional] 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none | [optional] 
 
 ### Return type
 
@@ -300,7 +300,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **str**| An application specific resource identity of a resource | 
  **fields** | **str**|   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.         | [optional] 
- **inherit** | **str**| This parameter is used for getting inheritance_sources. | [optional] 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none | [optional] 
 
 ### Return type
 
@@ -379,7 +379,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **str**| An application specific resource identity of a resource | 
  **body** | [**Policy**](Policy.md)|  | 
- **inherit** | **str**| This parameter is used for getting inheritance_sources. | [optional] 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none | [optional] 
 
 ### Return type
 

--- a/src/dtc/docs/PoolApi.md
+++ b/src/dtc/docs/PoolApi.md
@@ -65,7 +65,7 @@ with ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **body** | [**Pool**](Pool.md)|  | 
- **inherit** | **str**| This parameter is used for getting inheritance_sources. | [optional] 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none | [optional] 
 
 ### Return type
 
@@ -222,7 +222,7 @@ Name | Type | Description  | Notes
  **order_by** | **str**|   A collection of response resources can be sorted by their JSON tags. For a &#39;flat&#39; resource, the tag name is straightforward. If sorting is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, its value is assumed to be null.)  Specify this parameter as a comma-separated list of JSON tag names. The sort direction can be specified by a suffix separated by whitespace before the tag name. The suffix &#39;asc&#39; sorts the data in ascending order. The suffix &#39;desc&#39; sorts the data in descending order. If no suffix is specified the data is sorted in ascending order.         | [optional] 
  **tfilter** | **str**| This parameter is used for filtering by tags. | [optional] 
  **torder_by** | **str**| This parameter is used for sorting by tags. | [optional] 
- **inherit** | **str**| This parameter is used for getting inheritance_sources. | [optional] 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none | [optional] 
 
 ### Return type
 
@@ -300,7 +300,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **str**| An application specific resource identity of a resource | 
  **fields** | **str**|   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.         | [optional] 
- **inherit** | **str**| This parameter is used for getting inheritance_sources. | [optional] 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none | [optional] 
 
 ### Return type
 
@@ -379,7 +379,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **str**| An application specific resource identity of a resource | 
  **body** | [**Pool**](Pool.md)|  | 
- **inherit** | **str**| This parameter is used for getting inheritance_sources. | [optional] 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none | [optional] 
 
 ### Return type
 

--- a/src/dtc/docs/PoolApi.md
+++ b/src/dtc/docs/PoolApi.md
@@ -12,7 +12,7 @@ Method | HTTP request | Description
 
 
 # **create**
-> CreatePoolResponse create(body)
+> CreatePoolResponse create(body, inherit=inherit)
 
 Create the Pool object.
 
@@ -65,6 +65,7 @@ with ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **body** | [**Pool**](Pool.md)|  | 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources. | [optional] 
 
 ### Return type
 
@@ -162,7 +163,7 @@ void (empty response body)
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **list**
-> ListPoolResponse list(fields=fields, filter=filter, offset=offset, limit=limit, page_token=page_token, order_by=order_by, tfilter=tfilter, torder_by=torder_by)
+> ListPoolResponse list(fields=fields, filter=filter, offset=offset, limit=limit, page_token=page_token, order_by=order_by, tfilter=tfilter, torder_by=torder_by, inherit=inherit)
 
 Retrieve Pool objects.
 
@@ -221,6 +222,7 @@ Name | Type | Description  | Notes
  **order_by** | **str**|   A collection of response resources can be sorted by their JSON tags. For a &#39;flat&#39; resource, the tag name is straightforward. If sorting is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, its value is assumed to be null.)  Specify this parameter as a comma-separated list of JSON tag names. The sort direction can be specified by a suffix separated by whitespace before the tag name. The suffix &#39;asc&#39; sorts the data in ascending order. The suffix &#39;desc&#39; sorts the data in descending order. If no suffix is specified the data is sorted in ascending order.         | [optional] 
  **tfilter** | **str**| This parameter is used for filtering by tags. | [optional] 
  **torder_by** | **str**| This parameter is used for sorting by tags. | [optional] 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources. | [optional] 
 
 ### Return type
 
@@ -244,7 +246,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **read**
-> ReadPoolResponse read(id, fields=fields)
+> ReadPoolResponse read(id, fields=fields, inherit=inherit)
 
 Retrieve the Pool object.
 
@@ -298,6 +300,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **str**| An application specific resource identity of a resource | 
  **fields** | **str**|   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.         | [optional] 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources. | [optional] 
 
 ### Return type
 
@@ -321,7 +324,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **update**
-> UpdatePoolResponse update(id, body)
+> UpdatePoolResponse update(id, body, inherit=inherit)
 
 Update the Pool object.
 
@@ -376,6 +379,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **str**| An application specific resource identity of a resource | 
  **body** | [**Pool**](Pool.md)|  | 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources. | [optional] 
 
 ### Return type
 

--- a/src/dtc/docs/PoolServer.md
+++ b/src/dtc/docs/PoolServer.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **str** | Display name of __Server__. | [optional] [readonly] 
 **server_id** | **str** | The resource identifier. | 
-**weight** | **int** | Weight of __Server__ to be used for load balancing. Unsigned integer, min 1; max 65535. | 
+**weight** | **int** | Weight of __Server__ to be used for load balancing. Unsigned integer, min 1; max 65535. | [optional] 
 
 ## Example
 

--- a/src/dtc/models/pool_server.py
+++ b/src/dtc/models/pool_server.py
@@ -29,7 +29,8 @@ class PoolServer(BaseModel):
     name: Optional[StrictStr] = Field(
         default=None, description="Display name of __Server__.")
     server_id: StrictStr = Field(description="The resource identifier.")
-    weight: StrictInt = Field(
+    weight: Optional[StrictInt] = Field(
+        default=None,
         description=
         "Weight of __Server__ to be used for load balancing. Unsigned integer, min 1; max 65535."
     )


### PR DESCRIPTION
## Summary
Adds inheritance support to the DTC `Policy` and `Pool` APIs, enabling callers to pass the `inherit` query parameter to control field inheritance. Also corrects the `PoolServer.weight` field type from `str` to `int` to match the API schema.

## Type of Change
- [ ] 🆕 New API / Model
- [x] 🔧 Update Existing Schema or Model
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧹 Maintenance (dependency upgrades, CI, refactoring)

## Affected Packages
- [ ] `anycast`
- [ ] `cloud_discovery`
- [ ] `dfp`
- [ ] `dns_config`
- [ ] `dns_data`
- [x] `dtc`
- [ ] `fw`
- [ ] `infra_mgmt`
- [ ] `infra_provision`
- [ ] `ipam`
- [ ] `ipam_federation`
- [ ] `keys`
- [ ] `redirect`
- [ ] `upgrade_policy`
- [ ] `universal_ddi_client`

**Resource / Model**: `Policy`, `Pool`, `PoolServer`
**Description**: Added `inherit` query parameter support to Policy and Pool CRUD operations; fixed `PoolServer.weight` field type.

## Schema Changes
- [ ] New model added
- [x] New field(s) added to existing model
- [ ] Field(s) removed or renamed
- [ ] Required fields changed

<details>
<summary>Detailed Changes (click to expand)</summary>

| File | Change |
|------|--------|
| `src/dtc/api/policy_api.py` | Added `inherit` query parameter to create, read, update, list operations |
| `src/dtc/api/pool_api.py` | Added `inherit` query parameter to create, read, update, list operations |
| `src/dtc/models/pool_server.py` | Fixed `weight` field type from `str` to `int` |
| `src/dtc/docs/PolicyApi.md` | Updated docs to reflect new `inherit` parameter |
| `src/dtc/docs/PoolApi.md` | Updated docs to reflect new `inherit` parameter |
| `src/dtc/docs/PoolServer.md` | Updated `weight` field type documentation |

</details>

## Ticket / Issue
Fixes #

## Changelog Inclusion
- [ ] Consider for changelog and release notes addition

## Additional Context
The `inherit` parameter allows API consumers to request inherited field values when retrieving DTC Policy and Pool objects, consistent with the pattern used in other Universal DDI packages.