### PR TITLE
[DTC] Client changes to set Weight as an Optional field for Policy 

### DIFF
--- a/src/dtc/docs/PolicyPool.md
+++ b/src/dtc/docs/PolicyPool.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **str** | Display name of __Pool__. | [optional] [readonly] 
 **pool_id** | **str** | The resource identifier. | 
-**weight** | **int** | Weight of __Pool__ to be used for load balancing. Unsigned integer, min 1; max 65535. | 
+**weight** | **int** | Weight of __Pool__ to be used for load balancing. Unsigned integer, min 1; max 65535. | [optional] 
 
 ## Example
 

--- a/src/dtc/models/policy_pool.py
+++ b/src/dtc/models/policy_pool.py
@@ -29,7 +29,8 @@ class PolicyPool(BaseModel):
     name: Optional[StrictStr] = Field(default=None,
                                       description="Display name of __Pool__.")
     pool_id: StrictStr = Field(description="The resource identifier.")
-    weight: StrictInt = Field(
+    weight: Optional[StrictInt] = Field(
+        default=None,
         description=
         "Weight of __Pool__ to be used for load balancing. Unsigned integer, min 1; max 65535."
     )


### PR DESCRIPTION
## Summary
Sets `weight` as an optional field on the `PolicyPool` model to align with the upstream API schema, where `weight` is not required when associating a pool to a DTC policy.

## Type of Change
- [ ] 🆕 New API / Model
- [x] 🔧 Update Existing Schema or Model
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧹 Maintenance (dependency upgrades, CI, refactoring)

## Affected Packages
- [ ] `anycast`
- [ ] `cloud_discovery`
- [ ] `dfp`
- [ ] `dns_config`
- [ ] `dns_data`
- [x] `dtc`
- [ ] `fw`
- [ ] `infra_mgmt`
- [ ] `infra_provision`
- [ ] `ipam`
- [ ] `ipam_federation`
- [ ] `keys`
- [ ] `redirect`
- [ ] `upgrade_policy`
- [ ] `universal_ddi_client`

**Resource / Model**: `PolicyPool`
**Description**: Changed `weight` on `PolicyPool` from required to optional (default `None`).

## Schema Changes
- [ ] New model added
- [ ] New field(s) added to existing model
- [ ] Field(s) removed or renamed
- [x] Required fields changed

<details>
<summary>Detailed Changes (click to expand)</summary>

| File | Change |
|------|--------|
| `src/dtc/models/policy_pool.py` | Changed `weight` field to `Optional[int] = None` |
| `src/dtc/docs/PolicyPool.md` | Updated `weight` field documentation to mark as optional |

</details>

## Ticket / Issue
Fixes #

## Changelog Inclusion
- [ ] Consider for changelog and release notes addition

## Additional Context
Without this fix, creating a `PolicyPool` without explicitly specifying a weight would raise a validation error, even though the upstream API treats it as optional.