### PR TITLE
Added inheritance support for DTC LBDN and included python client changes for compartment ID

### DIFF
--- a/src/dns_config/api/lbdn_api.py
+++ b/src/dns_config/api/lbdn_api.py
@@ -47,6 +47,12 @@ class LbdnApi:
     def create(
         self,
         body: LBDN,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -64,6 +70,8 @@ class LbdnApi:
 
         :param body: (required)
         :type body: LBDN
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -87,6 +95,7 @@ class LbdnApi:
         """ # noqa: E501
 
         _param = self._create_serialize(body=body,
+                                        inherit=inherit,
                                         _request_auth=_request_auth,
                                         _content_type=_content_type,
                                         _headers=_headers,
@@ -108,6 +117,12 @@ class LbdnApi:
     def create_with_http_info(
         self,
         body: LBDN,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -125,6 +140,8 @@ class LbdnApi:
 
         :param body: (required)
         :type body: LBDN
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -148,6 +165,7 @@ class LbdnApi:
         """ # noqa: E501
 
         _param = self._create_serialize(body=body,
+                                        inherit=inherit,
                                         _request_auth=_request_auth,
                                         _content_type=_content_type,
                                         _headers=_headers,
@@ -169,6 +187,12 @@ class LbdnApi:
     def create_without_preload_content(
         self,
         body: LBDN,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -186,6 +210,8 @@ class LbdnApi:
 
         :param body: (required)
         :type body: LBDN
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -209,6 +235,7 @@ class LbdnApi:
         """ # noqa: E501
 
         _param = self._create_serialize(body=body,
+                                        inherit=inherit,
                                         _request_auth=_request_auth,
                                         _content_type=_content_type,
                                         _headers=_headers,
@@ -224,6 +251,7 @@ class LbdnApi:
     def _create_serialize(
         self,
         body,
+        inherit,
         _request_auth,
         _content_type,
         _headers,
@@ -243,6 +271,10 @@ class LbdnApi:
 
         # process the path parameters
         # process the query parameters
+        if inherit is not None:
+
+            _query_params.append(('_inherit', inherit))
+
         # process the header parameters
         # process the form parameters
         # process the body parameter
@@ -561,6 +593,12 @@ class LbdnApi:
             Optional[StrictStr],
             Field(description="This parameter is used for sorting by tags."
                   )] = None,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -592,6 +630,8 @@ class LbdnApi:
         :type tfilter: str
         :param torder_by: This parameter is used for sorting by tags.
         :type torder_by: str
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -622,6 +662,7 @@ class LbdnApi:
                                       order_by=order_by,
                                       tfilter=tfilter,
                                       torder_by=torder_by,
+                                      inherit=inherit,
                                       _request_auth=_request_auth,
                                       _content_type=_content_type,
                                       _headers=_headers,
@@ -686,6 +727,12 @@ class LbdnApi:
             Optional[StrictStr],
             Field(description="This parameter is used for sorting by tags."
                   )] = None,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -717,6 +764,8 @@ class LbdnApi:
         :type tfilter: str
         :param torder_by: This parameter is used for sorting by tags.
         :type torder_by: str
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -747,6 +796,7 @@ class LbdnApi:
                                       order_by=order_by,
                                       tfilter=tfilter,
                                       torder_by=torder_by,
+                                      inherit=inherit,
                                       _request_auth=_request_auth,
                                       _content_type=_content_type,
                                       _headers=_headers,
@@ -811,6 +861,12 @@ class LbdnApi:
             Optional[StrictStr],
             Field(description="This parameter is used for sorting by tags."
                   )] = None,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -842,6 +898,8 @@ class LbdnApi:
         :type tfilter: str
         :param torder_by: This parameter is used for sorting by tags.
         :type torder_by: str
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -872,6 +930,7 @@ class LbdnApi:
                                       order_by=order_by,
                                       tfilter=tfilter,
                                       torder_by=torder_by,
+                                      inherit=inherit,
                                       _request_auth=_request_auth,
                                       _content_type=_content_type,
                                       _headers=_headers,
@@ -894,6 +953,7 @@ class LbdnApi:
         order_by,
         tfilter,
         torder_by,
+        inherit,
         _request_auth,
         _content_type,
         _headers,
@@ -945,6 +1005,10 @@ class LbdnApi:
 
             _query_params.append(('_torder_by', torder_by))
 
+        if inherit is not None:
+
+            _query_params.append(('_inherit', inherit))
+
         # process the header parameters
         # process the form parameters
         # process the body parameter
@@ -984,6 +1048,12 @@ class LbdnApi:
                 description=
                 "  A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        "
             )] = None,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1003,6 +1073,8 @@ class LbdnApi:
         :type id: str
         :param fields:   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        
         :type fields: str
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1027,6 +1099,7 @@ class LbdnApi:
 
         _param = self._read_serialize(id=id,
                                       fields=fields,
+                                      inherit=inherit,
                                       _request_auth=_request_auth,
                                       _content_type=_content_type,
                                       _headers=_headers,
@@ -1057,6 +1130,12 @@ class LbdnApi:
                 description=
                 "  A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        "
             )] = None,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1076,6 +1155,8 @@ class LbdnApi:
         :type id: str
         :param fields:   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        
         :type fields: str
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1100,6 +1181,7 @@ class LbdnApi:
 
         _param = self._read_serialize(id=id,
                                       fields=fields,
+                                      inherit=inherit,
                                       _request_auth=_request_auth,
                                       _content_type=_content_type,
                                       _headers=_headers,
@@ -1130,6 +1212,12 @@ class LbdnApi:
                 description=
                 "  A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        "
             )] = None,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1149,6 +1237,8 @@ class LbdnApi:
         :type id: str
         :param fields:   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.        
         :type fields: str
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1173,6 +1263,7 @@ class LbdnApi:
 
         _param = self._read_serialize(id=id,
                                       fields=fields,
+                                      inherit=inherit,
                                       _request_auth=_request_auth,
                                       _content_type=_content_type,
                                       _headers=_headers,
@@ -1189,6 +1280,7 @@ class LbdnApi:
         self,
         id,
         fields,
+        inherit,
         _request_auth,
         _content_type,
         _headers,
@@ -1213,6 +1305,10 @@ class LbdnApi:
         if fields is not None:
 
             _query_params.append(('_fields', fields))
+
+        if inherit is not None:
+
+            _query_params.append(('_inherit', inherit))
 
         # process the header parameters
         # process the form parameters
@@ -1248,6 +1344,12 @@ class LbdnApi:
             Field(description=
                   "An application specific resource identity of a resource")],
         body: LBDN,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1267,6 +1369,8 @@ class LbdnApi:
         :type id: str
         :param body: (required)
         :type body: LBDN
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1291,6 +1395,7 @@ class LbdnApi:
 
         _param = self._update_serialize(id=id,
                                         body=body,
+                                        inherit=inherit,
                                         _request_auth=_request_auth,
                                         _content_type=_content_type,
                                         _headers=_headers,
@@ -1316,6 +1421,12 @@ class LbdnApi:
             Field(description=
                   "An application specific resource identity of a resource")],
         body: LBDN,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1335,6 +1446,8 @@ class LbdnApi:
         :type id: str
         :param body: (required)
         :type body: LBDN
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1359,6 +1472,7 @@ class LbdnApi:
 
         _param = self._update_serialize(id=id,
                                         body=body,
+                                        inherit=inherit,
                                         _request_auth=_request_auth,
                                         _content_type=_content_type,
                                         _headers=_headers,
@@ -1384,6 +1498,12 @@ class LbdnApi:
             Field(description=
                   "An application specific resource identity of a resource")],
         body: LBDN,
+        inherit: Annotated[
+            Optional[StrictStr],
+            Field(
+                description=
+                "This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none"
+            )] = None,
         _request_timeout: Union[None, Annotated[StrictFloat,
                                                 Field(gt=0)],
                                 Tuple[Annotated[StrictFloat,
@@ -1403,6 +1523,8 @@ class LbdnApi:
         :type id: str
         :param body: (required)
         :type body: LBDN
+        :param inherit: This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none
+        :type inherit: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1427,6 +1549,7 @@ class LbdnApi:
 
         _param = self._update_serialize(id=id,
                                         body=body,
+                                        inherit=inherit,
                                         _request_auth=_request_auth,
                                         _content_type=_content_type,
                                         _headers=_headers,
@@ -1443,6 +1566,7 @@ class LbdnApi:
         self,
         id,
         body,
+        inherit,
         _request_auth,
         _content_type,
         _headers,
@@ -1464,6 +1588,10 @@ class LbdnApi:
         if id is not None:
             _path_params['id'] = self.api_client.path_param_value('id', id)
         # process the query parameters
+        if inherit is not None:
+
+            _query_params.append(('_inherit', inherit))
+
         # process the header parameters
         # process the form parameters
         # process the body parameter

--- a/src/dns_config/docs/ACL.md
+++ b/src/dns_config/docs/ACL.md
@@ -7,6 +7,7 @@ Named ACL (Access Control List).
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **comment** | **str** | Optional. Comment for ACL. | [optional] 
+**compartment_id** | **str** | The access view associated with the object. If no access view is associated with the object, the value defaults to empty. | [optional] 
 **id** | **str** | The resource identifier. | [optional] [readonly] 
 **list** | [**List[ACLItem]**](ACLItem.md) | Optional. Ordered list of access control elements.  Elements are evaluated in order to determine access. If evaluation reaches the end of the list then access is denied. | [optional] 
 **name** | **str** | ACL object name. | 

--- a/src/dns_config/docs/AuthZone.md
+++ b/src/dns_config/docs/AuthZone.md
@@ -7,6 +7,7 @@ Authoritative zone.
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **comment** | **str** | Optional. Comment for zone configuration. | [optional] 
+**compartment_id** | **str** | The access view associated with the object. If no access view is associated with the object, the value defaults to empty. | [optional] 
 **created_at** | **datetime** | Time when the object has been created. | [optional] [readonly] 
 **disabled** | **bool** | Optional. _true_ to disable object. A disabled object is effectively non-existent when generating configuration. | [optional] 
 **external_primaries** | [**List[ExternalPrimary]**](ExternalPrimary.md) | Optional. DNS primaries external to BloxOne DDI. Order is not significant. | [optional] 

--- a/src/dns_config/docs/Delegation.md
+++ b/src/dns_config/docs/Delegation.md
@@ -7,6 +7,7 @@ DNS zone delegation.
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **comment** | **str** | Optional. Comment for zone delegation. | [optional] 
+**compartment_id** | **str** | The access view associated with the object. If no access view is associated with the object, the value defaults to empty. | [optional] 
 **delegation_servers** | [**List[DelegationServer]**](DelegationServer.md) | Required. DNS zone delegation servers. Order is not significant. | [optional] 
 **disabled** | **bool** | Optional. _true_ to disable object. A disabled object is effectively non-existent when generating resource records. | [optional] 
 **fqdn** | **str** | Delegation FQDN. The FQDN supplied at creation will be converted to canonical form.  Read-only after creation. | [optional] 

--- a/src/dns_config/docs/ForwardZone.md
+++ b/src/dns_config/docs/ForwardZone.md
@@ -7,6 +7,7 @@ Forward zone
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **comment** | **str** | Optional. Comment for zone configuration. | [optional] 
+**compartment_id** | **str** | The access view associated with the object. If no access view is associated with the object, the value defaults to empty. | [optional] 
 **created_at** | **datetime** | The timestamp when the object has been created. | [optional] [readonly] 
 **disabled** | **bool** | Optional. _true_ to disable object. A disabled object is effectively non-existent when generating configuration. | [optional] 
 **external_forwarders** | [**List[Forwarder]**](Forwarder.md) | Optional. External DNS servers to forward to. Order is not significant. | [optional] 

--- a/src/dns_config/docs/LbdnApi.md
+++ b/src/dns_config/docs/LbdnApi.md
@@ -12,7 +12,7 @@ Method | HTTP request | Description
 
 
 # **create**
-> CreateLBDNResponse create(body)
+> CreateLBDNResponse create(body, inherit=inherit)
 
 Create the __LBDN__ object.
 
@@ -65,6 +65,7 @@ with ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **body** | [**LBDN**](LBDN.md)|  | 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none | [optional] 
 
 ### Return type
 
@@ -162,7 +163,7 @@ void (empty response body)
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **list**
-> ListLBDNResponse list(fields=fields, filter=filter, offset=offset, limit=limit, page_token=page_token, order_by=order_by, tfilter=tfilter, torder_by=torder_by)
+> ListLBDNResponse list(fields=fields, filter=filter, offset=offset, limit=limit, page_token=page_token, order_by=order_by, tfilter=tfilter, torder_by=torder_by, inherit=inherit)
 
 List __LBDN__ objects.
 
@@ -221,6 +222,7 @@ Name | Type | Description  | Notes
  **order_by** | **str**|   A collection of response resources can be sorted by their JSON tags. For a &#39;flat&#39; resource, the tag name is straightforward. If sorting is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, its value is assumed to be null.)  Specify this parameter as a comma-separated list of JSON tag names. The sort direction can be specified by a suffix separated by whitespace before the tag name. The suffix &#39;asc&#39; sorts the data in ascending order. The suffix &#39;desc&#39; sorts the data in descending order. If no suffix is specified the data is sorted in ascending order.         | [optional] 
  **tfilter** | **str**| This parameter is used for filtering by tags. | [optional] 
  **torder_by** | **str**| This parameter is used for sorting by tags. | [optional] 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none | [optional] 
 
 ### Return type
 
@@ -244,7 +246,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **read**
-> ReadLBDNResponse read(id, fields=fields)
+> ReadLBDNResponse read(id, fields=fields, inherit=inherit)
 
 Read the __LBDN__ object.
 
@@ -298,6 +300,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **str**| An application specific resource identity of a resource | 
  **fields** | **str**|   A collection of response resources can be transformed by specifying a set of JSON tags to be returned. For a “flat” resource, the tag name is straightforward. If field selection is allowed on non-flat hierarchical resources, the service should implement a qualified naming scheme such as dot-qualification to reference data down the hierarchy. If a resource does not have the specified tag, the tag does not appear in the output resource.  Specify this parameter as a comma-separated list of JSON tag names.         | [optional] 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none | [optional] 
 
 ### Return type
 
@@ -321,7 +324,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **update**
-> UpdateLBDNResponse update(id, body)
+> UpdateLBDNResponse update(id, body, inherit=inherit)
 
 Update the __LBDN__ object.
 
@@ -376,6 +379,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **str**| An application specific resource identity of a resource | 
  **body** | [**LBDN**](LBDN.md)|  | 
+ **inherit** | **str**| This parameter is used for getting inheritance_sources.  Allowed values: * _none_, * _partial_, * _full_.  Defaults to _none | [optional] 
 
 ### Return type
 

--- a/src/dns_config/docs/View.md
+++ b/src/dns_config/docs/View.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **add_edns_option_in_outgoing_query** | **bool** | _add_edns_option_in_outgoing_query_ adds client IP, MAC address and view name into outgoing recursive query. Defaults to _false_. | [optional] 
 **comment** | **str** | Optional. Comment for view. | [optional] 
+**compartment_id** | **str** | The access view associated with the object. If no access view is associated with the object, the value defaults to empty. | [optional] 
 **created_at** | **datetime** | The timestamp when the object has been created. | [optional] [readonly] 
 **custom_root_ns** | [**List[RootNS]**](RootNS.md) | Optional. List of custom root nameservers. The order does not matter.  Error if empty while _custom_root_ns_enabled_ is _true_. Error if there are duplicate items in the list.  Defaults to empty. | [optional] 
 **custom_root_ns_enabled** | **bool** | Optional. _true_ to use custom root nameservers instead of the default ones.  The _custom_root_ns_ is validated when enabled.  Defaults to _false_. | [optional] 

--- a/src/dns_config/models/acl.py
+++ b/src/dns_config/models/acl.py
@@ -31,6 +31,11 @@ class ACL(BaseModel):
   # noqa: E501
     comment: Optional[StrictStr] = Field(
         default=None, description="Optional. Comment for ACL.")
+    compartment_id: Optional[StrictStr] = Field(
+        default=None,
+        description=
+        "The access view associated with the object. If no access view is associated with the object, the value defaults to empty."
+    )
     id: Optional[StrictStr] = Field(default=None,
                                     description="The resource identifier.")
     list: Optional[List[ACLItem]] = Field(
@@ -43,7 +48,7 @@ class ACL(BaseModel):
                                            description="Tagging specifics.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = [
-        "comment", "id", "list", "name", "tags"
+        "comment", "compartment_id", "id", "list", "name", "tags"
     ]
 
     model_config = ConfigDict(
@@ -114,6 +119,8 @@ class ACL(BaseModel):
         _obj = cls.model_validate({
             "comment":
             obj.get("comment"),
+            "compartment_id":
+            obj.get("compartment_id"),
             "id":
             obj.get("id"),
             "list": [ACLItem.from_dict(_item) for _item in obj["list"]]

--- a/src/dns_config/models/auth_zone.py
+++ b/src/dns_config/models/auth_zone.py
@@ -40,6 +40,11 @@ class AuthZone(BaseModel):
   # noqa: E501
     comment: Optional[StrictStr] = Field(
         default=None, description="Optional. Comment for zone configuration.")
+    compartment_id: Optional[StrictStr] = Field(
+        default=None,
+        description=
+        "The access view associated with the object. If no access view is associated with the object, the value defaults to empty."
+    )
     created_at: Optional[datetime] = Field(
         default=None, description="Time when the object has been created.")
     disabled: Optional[StrictBool] = Field(
@@ -148,9 +153,9 @@ class AuthZone(BaseModel):
         default=None, description="Optional. ZoneAuthority.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = [
-        "comment", "created_at", "disabled", "external_primaries",
-        "external_providers", "external_secondaries", "fqdn",
-        "gss_tsig_enabled", "id", "inheritance_assigned_hosts",
+        "comment", "compartment_id", "created_at", "disabled",
+        "external_primaries", "external_providers", "external_secondaries",
+        "fqdn", "gss_tsig_enabled", "id", "inheritance_assigned_hosts",
         "inheritance_sources", "initial_soa_serial", "internal_secondaries",
         "mapped_subnet", "mapping", "notify", "nsgs", "parent", "primary_type",
         "protocol_fqdn", "query_acl", "tags", "transfer_acl", "update_acl",
@@ -304,6 +309,8 @@ class AuthZone(BaseModel):
         _obj = cls.model_validate({
             "comment":
             obj.get("comment"),
+            "compartment_id":
+            obj.get("compartment_id"),
             "created_at":
             obj.get("created_at"),
             "disabled":

--- a/src/dns_config/models/delegation.py
+++ b/src/dns_config/models/delegation.py
@@ -31,6 +31,11 @@ class Delegation(BaseModel):
   # noqa: E501
     comment: Optional[StrictStr] = Field(
         default=None, description="Optional. Comment for zone delegation.")
+    compartment_id: Optional[StrictStr] = Field(
+        default=None,
+        description=
+        "The access view associated with the object. If no access view is associated with the object, the value defaults to empty."
+    )
     delegation_servers: Optional[List[DelegationServer]] = Field(
         default=None,
         description=
@@ -57,8 +62,8 @@ class Delegation(BaseModel):
                                       description="The resource identifier.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = [
-        "comment", "delegation_servers", "disabled", "fqdn", "id", "parent",
-        "protocol_fqdn", "tags", "view"
+        "comment", "compartment_id", "delegation_servers", "disabled", "fqdn",
+        "id", "parent", "protocol_fqdn", "tags", "view"
     ]
 
     model_config = ConfigDict(
@@ -131,6 +136,8 @@ class Delegation(BaseModel):
         _obj = cls.model_validate({
             "comment":
             obj.get("comment"),
+            "compartment_id":
+            obj.get("compartment_id"),
             "delegation_servers": [
                 DelegationServer.from_dict(_item)
                 for _item in obj["delegation_servers"]

--- a/src/dns_config/models/forward_zone.py
+++ b/src/dns_config/models/forward_zone.py
@@ -33,6 +33,11 @@ class ForwardZone(BaseModel):
   # noqa: E501
     comment: Optional[StrictStr] = Field(
         default=None, description="Optional. Comment for zone configuration.")
+    compartment_id: Optional[StrictStr] = Field(
+        default=None,
+        description=
+        "The access view associated with the object. If no access view is associated with the object, the value defaults to empty."
+    )
     created_at: Optional[datetime] = Field(
         default=None,
         description="The timestamp when the object has been created.")
@@ -88,10 +93,10 @@ class ForwardZone(BaseModel):
         default=None, description="The list of a forward zone warnings.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = [
-        "comment", "created_at", "disabled", "external_forwarders",
-        "forward_only", "fqdn", "hosts", "id", "internal_forwarders",
-        "mapped_subnet", "mapping", "nsgs", "parent", "protocol_fqdn", "tags",
-        "updated_at", "view", "warnings"
+        "comment", "compartment_id", "created_at", "disabled",
+        "external_forwarders", "forward_only", "fqdn", "hosts", "id",
+        "internal_forwarders", "mapped_subnet", "mapping", "nsgs", "parent",
+        "protocol_fqdn", "tags", "updated_at", "view", "warnings"
     ]
 
     model_config = ConfigDict(
@@ -181,6 +186,8 @@ class ForwardZone(BaseModel):
         _obj = cls.model_validate({
             "comment":
             obj.get("comment"),
+            "compartment_id":
+            obj.get("compartment_id"),
             "created_at":
             obj.get("created_at"),
             "disabled":

--- a/src/dns_config/models/view.py
+++ b/src/dns_config/models/view.py
@@ -45,6 +45,11 @@ class View(BaseModel):
     )
     comment: Optional[StrictStr] = Field(
         default=None, description="Optional. Comment for view.")
+    compartment_id: Optional[StrictStr] = Field(
+        default=None,
+        description=
+        "The access view associated with the object. If no access view is associated with the object, the value defaults to empty."
+    )
     created_at: Optional[datetime] = Field(
         default=None,
         description="The timestamp when the object has been created.")
@@ -251,8 +256,8 @@ class View(BaseModel):
         default=None, description="Optional. ZoneAuthority.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = [
-        "add_edns_option_in_outgoing_query", "comment", "created_at",
-        "custom_root_ns", "custom_root_ns_enabled", "disabled",
+        "add_edns_option_in_outgoing_query", "comment", "compartment_id",
+        "created_at", "custom_root_ns", "custom_root_ns_enabled", "disabled",
         "dnssec_enable_validation", "dnssec_enabled", "dnssec_root_keys",
         "dnssec_trust_anchors", "dnssec_validate_expiry", "dtc_config",
         "ecs_enabled", "ecs_forwarding", "ecs_prefix_v4", "ecs_prefix_v6",
@@ -437,6 +442,8 @@ class View(BaseModel):
             obj.get("add_edns_option_in_outgoing_query"),
             "comment":
             obj.get("comment"),
+            "compartment_id":
+            obj.get("compartment_id"),
             "created_at":
             obj.get("created_at"),
             "custom_root_ns":


### PR DESCRIPTION
## Summary
Adds two improvements to the `dns_config` package: (1) inheritance support for the DTC LBDN API via a new `inherit` query parameter, and (2) a `compartment_id` field on `ACL`, `AuthZone`, `Delegation`, `ForwardZone`, and `View` models to support multi-tenancy compartment filtering.

## Type of Change
- [ ] 🆕 New API / Model
- [x] 🔧 Update Existing Schema or Model
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧹 Maintenance (dependency upgrades, CI, refactoring)

## Affected Packages
- [ ] `anycast`
- [ ] `cloud_discovery`
- [ ] `dfp`
- [x] `dns_config`
- [ ] `dns_data`
- [ ] `dtc`
- [ ] `fw`
- [ ] `infra_mgmt`
- [ ] `infra_provision`
- [ ] `ipam`
- [ ] `ipam_federation`
- [ ] `keys`
- [ ] `redirect`
- [ ] `upgrade_policy`
- [ ] `universal_ddi_client`

**Resource / Model**: `LbdnApi`, `ACL`, `AuthZone`, `Delegation`, `ForwardZone`, `View`
**Description**: Added `inherit` query param to LBDN API; added `compartment_id` field to five DNS Config models.

## Schema Changes
- [ ] New model added
- [x] New field(s) added to existing model
- [ ] Field(s) removed or renamed
- [ ] Required fields changed

<details>
<summary>Detailed Changes (click to expand)</summary>

| File | Change |
|------|--------|
| `src/dns_config/api/lbdn_api.py` | Added `inherit` query parameter to LBDN CRUD operations |
| `src/dns_config/models/acl.py` | Added optional `compartment_id` field |
| `src/dns_config/models/auth_zone.py` | Added optional `compartment_id` field |
| `src/dns_config/models/delegation.py` | Added optional `compartment_id` field |
| `src/dns_config/models/forward_zone.py` | Added optional `compartment_id` field |
| `src/dns_config/models/view.py` | Added optional `compartment_id` field |
| `src/dns_config/docs/LbdnApi.md` | Updated to document `inherit` query parameter |
| `src/dns_config/docs/*.md` | Updated model docs to include `compartment_id` field |

</details>

## Ticket / Issue
Fixes #

## Changelog Inclusion
- [x] Consider for changelog and release notes addition

## Additional Context
The `compartment_id` field supports Infoblox's multi-tenancy model, allowing DNS resources to be scoped to a specific compartment. This mirrors similar changes already made in other packages.